### PR TITLE
Fix MeteoSwiss collection metadata

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -13,10 +13,10 @@ Station-level time series in CSV, split into time slices (`historical`, `recent`
 | `smn` | A1 | **Automatic weather stations** -- the core SwissMetNet network. ~160 stations across Switzerland measuring temperature, humidity, pressure, precipitation, wind, radiation, sunshine, soil temperature, and dew point. | 10-min, hourly, daily, monthly, yearly | 158 | 181 |
 | `smn_precip` | A2 | **Automatic precipitation stations** -- rain-gauge-only network. Reports precipitation totals at multiple granularities. | 10-min, hourly, daily, monthly, yearly | 141 | 6 |
 | `smn_tower` | A3 | **Tower stations** -- tall mast measurements for temperature, humidity, wind (scalar + gusts), radiation, and sunshine at tower height. | 10-min, hourly, daily, monthly, yearly | 4 | 46 |
-| `nime` | A5 | **Manual precipitation stations** -- observer-read gauges reporting daily precipitation, plus fresh snow depth and snow cover. | daily, monthly, yearly | 273 | 17 |
+| `nime` | A5 | **Manual precipitation stations** -- observer-read gauges reporting daily precipitation, plus fresh snow depth and snow cover. | daily, monthly, yearly | 270 | 17 |
 | `tot` | A6 | **Totaliser precipitation** -- remote alpine rain gauges read once per year, reporting precipitation reduced to hydrological year (Oct 1 -- Sep 30). | yearly | 57 | 1 |
 | `pollen` | A7 | **Pollen stations** -- airborne pollen concentrations for 7 taxa: alder, birch, hazel, beech, ash, oak, and grasses (_Poaceae_). | hourly, daily, yearly | 16 | 28 |
-| `obs` | A8 | **Visual / meteorological observations** -- human-observed daily cloud cover, counts of days with rain, snowfall, hail, fog, and snow coverage. | daily, monthly, yearly | 20 | 27 |
+| `obs` | A8 | **Visual / meteorological observations** -- human-observed daily cloud cover, counts of days with rain, snowfall, hail, fog, and snow coverage. | daily, monthly, yearly | 8 | 27 |
 | `phenology` | A9 | **Phenological observations** -- day-of-year for lifecycle events (leaf unfolding, flowering, fruit maturity, leaf colouring, leaf drop) across 26 plant species including horse chestnut, beech, cherry, apple, grape vine, and larch. | yearly | 175 | 71 |
 
 ---
@@ -25,13 +25,13 @@ Station-level time series in CSV, split into time slices (`historical`, `recent`
 
 | Key | ID | Description | Format |
 |---|---|---|---|
-| `nbcn` | C1 | **Homogeneous climate stations** -- break-adjusted series for temperature, pressure, precipitation, sunshine, and cloud cover (29 stations). Used for long-term trend analysis. | CSV -> Parquet |
-| `nbcn_precip` | C2 | **Homogeneous precipitation** -- break-adjusted precipitation series (46 stations). | CSV -> Parquet |
+| `nbcn` | C1 | **Homogeneous climate stations** -- break-adjusted daily, monthly, and yearly series for temperature, pressure, precipitation, sunshine, and cloud cover (29 stations). Used for long-term trend analysis. | CSV -> Parquet |
+| `nbcn_precip` | C2 | **Homogeneous precipitation** -- break-adjusted monthly and yearly precipitation series (46 stations). | CSV -> Parquet |
 | `surface_derived_grid` | C3 | **Ground-based spatial analyses** -- gridded fields of precipitation, temperature, and sunshine duration derived from station interpolation. | NetCDF (opt-in) |
 | `satellite_derived_grid` | C4 | **Satellite-based spatial analyses** -- gridded radiation, cloud cover, and land surface temperature derived from satellite. | NetCDF (opt-in) |
 | `climate_normals` | C6 | **Station normals** -- 30-year reference averages for 1961--1990 and 1991--2020. Monthly values per station. | TXT -> Parquet |
 | `climate_normals_*` | C7 | **Spatial normals** -- gridded 30-year reference maps for precipitation, sunshine, and temperature (both reference periods). | NetCDF / GeoTIFF (opt-in) |
-| `climate_scenarios` | C8 | **CH2025 local scenarios** -- station-level climate projections. | CSV -> Parquet |
+| `climate_scenarios` | C8 | **CH2025 local scenarios** -- daily station-level climate projections. | CSV -> Parquet |
 | `climate_scenarios_grid` | C9 | **CH2025 gridded scenarios** -- spatially gridded climate projections. | NetCDF (opt-in) |
 
 ---
@@ -53,7 +53,7 @@ Radar collections are large and require `--grids` to download.
 |---|---|---|---|
 | `forecast_icon_ch1` | E2 | **ICON-CH1-EPS** -- 1 km ensemble forecast model over Switzerland. | GRIB2 (opt-in) |
 | `forecast_icon_ch2` | E3 | **ICON-CH2-EPS** -- 2.1 km ensemble forecast model. | GRIB2 (opt-in) |
-| `forecast_local` | E4 | **Local point forecasts** -- forecasts for ~5,600 points (stations + postal codes) covering temperature, precipitation, wind, radiation, and more (32 parameters). | CSV -> Parquet |
+| `forecast_local` | E4 | **Local point forecasts** -- hourly and daily forecasts for ~5,600 points (stations + postal codes) covering temperature, precipitation, wind, radiation, and more (32 parameters). | CSV -> Parquet |
 
 GRIB2 forecast collections are large and require `--grids` to download.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -12,7 +12,7 @@ import foehn
 foehn.list_datasets()
 # [{'dataset': 'smn', 'collection_id': 'ch.meteoschweiz.ogd-smn', 'category': 'A',
 #   'subcategory': 'A1', 'description': 'Automatic weather stations',
-#   'format': 'CSV', 'frequencies': ['t', 'h', 'd', 'm'],
+#   'format': 'CSV', 'frequencies': ['t', 'h', 'd', 'm', 'y'],
 #   'time_slices': ['historical', 'recent', 'now']}, ...]
 ```
 

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -60,21 +60,21 @@ STAC_API_BASE = "https://data.geo.admin.ch/api/stac/v1"
 #   C6 climate normals  → separate ZIP from opendata.swiss (not on STAC API)
 COLLECTIONS = {
     # ── A: Ground-based measurements (CSV, time-sliced: historical/recent/now) ──
-    "smn": "ch.meteoschweiz.ogd-smn",  # A1 — Automatic weather stations (t,h,d,m)
-    "smn_precip": "ch.meteoschweiz.ogd-smn-precip",  # A2 — Automatic precipitation stations (t,h,d,m)
-    "smn_tower": "ch.meteoschweiz.ogd-smn-tower",  # A3 — Automatic tower stations (t,h,d,m)
+    "smn": "ch.meteoschweiz.ogd-smn",  # A1 — Automatic weather stations (t,h,d,m,y)
+    "smn_precip": "ch.meteoschweiz.ogd-smn-precip",  # A2 — Automatic precipitation stations (t,h,d,m,y)
+    "smn_tower": "ch.meteoschweiz.ogd-smn-tower",  # A3 — Automatic tower stations (t,h,d,m,y)
     # A4 — Automatic soil moisture stations                     NOT YET RELEASED
     "nime": "ch.meteoschweiz.ogd-nime",  # A5 — Manual precipitation stations (d,m,y)
     "tot": "ch.meteoschweiz.ogd-tot",  # A6 — Totaliser precipitation (y, no time-slice)
-    "obs": "ch.meteoschweiz.ogd-obs",  # A8 — Meteorological visual observations (t,m,y)
-    "pollen": "ch.meteoschweiz.ogd-pollen",  # A7 — Pollen stations (h,d)
+    "obs": "ch.meteoschweiz.ogd-obs",  # A8 — Meteorological visual observations (d,m,y)
+    "pollen": "ch.meteoschweiz.ogd-pollen",  # A7 — Pollen stations (h,d,y)
     "phenology": "ch.meteoschweiz.ogd-phenology",  # A9 — Phenological observations (y, no time-slice)
     # ── B: Atmosphere measurements                             NOT YET RELEASED ──
     # B1 Radio soundings, B2 RALMO, B3 Ceilometer, B4-B5 Ozone, B6 SACRaM
     # ── C: Climate data ──────────────────────────────────────────────────────────
     # C1/C2 — Homogeneous series (CSV, time-sliced: historical/recent)
-    "nbcn": "ch.meteoschweiz.ogd-nbcn",  # C1 — Climate stations, homogeneous (d,m)
-    "nbcn_precip": "ch.meteoschweiz.ogd-nbcn-precip",  # C2 — Climate precipitation, homogeneous (m)
+    "nbcn": "ch.meteoschweiz.ogd-nbcn",  # C1 — Climate stations, homogeneous (d,m,y)
+    "nbcn_precip": "ch.meteoschweiz.ogd-nbcn-precip",  # C2 — Climate precipitation, homogeneous (m,y)
     # C3/C4 — Spatial climate analyses (NetCDF, static grids)
     "surface_derived_grid": "ch.meteoschweiz.ogd-surface-derived-grid",  # C3 — Precipitation, temperature, sunshine
     "satellite_derived_grid": "ch.meteoschweiz.ogd-satellite-derived-grid",  # C4 — Radiation, clouds, LST
@@ -118,7 +118,7 @@ COLLECTION_META: dict[str, dict] = {
         "subcategory": "A1",
         "description": "Automatic weather stations",
         "format": "CSV",
-        "frequencies": ["t", "h", "d", "m"],
+        "frequencies": ["t", "h", "d", "m", "y"],
         "time_slices": ["historical", "recent", "now"],
     },
     "smn_precip": {
@@ -126,7 +126,7 @@ COLLECTION_META: dict[str, dict] = {
         "subcategory": "A2",
         "description": "Automatic precipitation stations",
         "format": "CSV",
-        "frequencies": ["t", "h", "d", "m"],
+        "frequencies": ["t", "h", "d", "m", "y"],
         "time_slices": ["historical", "recent", "now"],
     },
     "smn_tower": {
@@ -134,7 +134,7 @@ COLLECTION_META: dict[str, dict] = {
         "subcategory": "A3",
         "description": "Automatic tower stations",
         "format": "CSV",
-        "frequencies": ["t", "h", "d", "m"],
+        "frequencies": ["t", "h", "d", "m", "y"],
         "time_slices": ["historical", "recent", "now"],
     },
     "nime": {
@@ -158,16 +158,16 @@ COLLECTION_META: dict[str, dict] = {
         "subcategory": "A8",
         "description": "Meteorological visual observations",
         "format": "CSV",
-        "frequencies": ["t", "m", "y"],
-        "time_slices": ["historical", "recent", "now"],
+        "frequencies": ["d", "m", "y"],
+        "time_slices": ["historical", "recent"],
     },
     "pollen": {
         "category": "A",
         "subcategory": "A7",
         "description": "Pollen stations",
         "format": "CSV",
-        "frequencies": ["h", "d"],
-        "time_slices": ["historical", "recent", "now"],
+        "frequencies": ["h", "d", "y"],
+        "time_slices": ["historical", "recent"],
     },
     "phenology": {
         "category": "A",
@@ -183,7 +183,7 @@ COLLECTION_META: dict[str, dict] = {
         "subcategory": "C1",
         "description": "Climate stations, homogeneous",
         "format": "CSV",
-        "frequencies": ["d", "m"],
+        "frequencies": ["d", "m", "y"],
         "time_slices": ["historical", "recent"],
     },
     "nbcn_precip": {
@@ -191,8 +191,8 @@ COLLECTION_META: dict[str, dict] = {
         "subcategory": "C2",
         "description": "Climate precipitation, homogeneous",
         "format": "CSV",
-        "frequencies": ["m"],
-        "time_slices": ["historical", "recent"],
+        "frequencies": ["m", "y"],
+        "time_slices": [],
     },
     "surface_derived_grid": {
         "category": "C",
@@ -263,7 +263,7 @@ COLLECTION_META: dict[str, dict] = {
         "subcategory": "C8",
         "description": "Climate scenarios CH2025 local",
         "format": "CSV",
-        "frequencies": ["y"],
+        "frequencies": ["d"],
         "time_slices": [],
     },
     "climate_scenarios_grid": {
@@ -320,7 +320,7 @@ COLLECTION_META: dict[str, dict] = {
         "category": "D",
         "subcategory": "D1",
         "description": "Precipitation radar",
-        "format": "GRIB2",
+        "format": "HDF5",
         "frequencies": [],
         "time_slices": [],
     },
@@ -328,7 +328,7 @@ COLLECTION_META: dict[str, dict] = {
         "category": "D",
         "subcategory": "D3",
         "description": "Hail radar",
-        "format": "GRIB2",
+        "format": "HDF5",
         "frequencies": [],
         "time_slices": [],
     },
@@ -354,7 +354,7 @@ COLLECTION_META: dict[str, dict] = {
         "subcategory": "E4",
         "description": "Local point forecasts",
         "format": "CSV",
-        "frequencies": [],
+        "frequencies": ["h", "d"],
         "time_slices": [],
     },
 }

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -58,3 +58,25 @@ def test_list_datasets_dict_keys():
 
 def test_collection_meta_covers_all_keys():
     assert set(COLLECTION_META.keys()) == set(COLLECTIONS.keys())
+
+
+def test_collection_meta_matches_live_stac_granularities():
+    expected = {
+        "smn": (["t", "h", "d", "m", "y"], ["historical", "recent", "now"]),
+        "smn_precip": (["t", "h", "d", "m", "y"], ["historical", "recent", "now"]),
+        "smn_tower": (["t", "h", "d", "m", "y"], ["historical", "recent", "now"]),
+        "obs": (["d", "m", "y"], ["historical", "recent"]),
+        "pollen": (["h", "d", "y"], ["historical", "recent"]),
+        "nbcn": (["d", "m", "y"], ["historical", "recent"]),
+        "nbcn_precip": (["m", "y"], []),
+        "climate_scenarios": (["d"], []),
+        "forecast_local": (["h", "d"], []),
+    }
+    for key, (frequencies, time_slices) in expected.items():
+        assert COLLECTION_META[key]["frequencies"] == frequencies
+        assert COLLECTION_META[key]["time_slices"] == time_slices
+
+
+def test_radar_collections_are_hdf5():
+    assert COLLECTION_META["radar_precip"]["format"] == "HDF5"
+    assert COLLECTION_META["radar_hail"]["format"] == "HDF5"


### PR DESCRIPTION
## Summary
- update MeteoSwiss collection frequency/time-slice metadata to match live STAC assets and parameter metadata
- correct radar collection formats from GRIB2 to HDF5
- refresh collection docs and Python API example
- add regression coverage for the corrected metadata

## Tests
- /Users/kayhendriksen/foehn/.venv/bin/python -m pytest

Note: this PR intentionally excludes the raster feature work.