### PR TITLE
Handle indoor climate scenarios as a zipped CSV collection

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -31,8 +31,9 @@ Station-level time series in CSV, split into time slices (`historical`, `recent`
 | `satellite_derived_grid` | C4 | **Satellite-based spatial analyses** -- gridded radiation, cloud cover, and land surface temperature derived from satellite. | NetCDF (opt-in) |
 | `climate_normals` | C6 | **Station normals** -- 30-year reference averages for 1961--1990 and 1991--2020. Monthly values per station. | TXT -> Parquet |
 | `climate_normals_*` | C7 | **Spatial normals** -- gridded 30-year reference maps for precipitation, sunshine, and temperature (both reference periods). | NetCDF / GeoTIFF (opt-in) |
-| `climate_scenarios` | C8 | **CH2025 local scenarios** -- daily station-level climate projections. | CSV -> Parquet |
+| `climate_scenarios` | C8 | **CH2025 local scenarios** -- daily station-level climate projections, one column per climate model. Dates are a nominal 30-year period (0001--0030 on a 365-day calendar), not real calendar dates. | CSV -> Parquet |
 | `climate_scenarios_grid` | C9 | **CH2025 gridded scenarios** -- spatially gridded climate projections. | NetCDF (opt-in) |
+| `climate_scenarios_indoor` | -- | **CH2025 indoor climate** -- hourly indoor-climate scenario series per station, scenario (RCP), and variant, delivered as a single ZIP of CSVs. | CSV+ZIP -> Parquet |
 
 ---
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -68,6 +68,22 @@ df = foehn.load("smn", station="BER", frequency="d", sort="desc")
 | `drop_null` | `str` | Drop rows where this column is null |
 | `sort` | `str` | Sort by timestamp: "asc" or "desc" |
 
+### Climate scenario collections
+
+The CH2025 scenario collections have their own layout but load the same way:
+
+```python
+# Indoor climate scenarios (CSV+ZIP): the whole archive is fetched once, then
+# filtered in memory by station.
+df = foehn.load("climate_scenarios_indoor", station="ABO")
+
+# Local climate scenarios (C8): a wide table with one column per climate model.
+# Dates are a nominal 30-year period (0001-01-01 .. 0030-12-31), so the calendar
+# filters (year/month/date_from/date_to) don't apply; `sort` orders by the
+# string `date` column.
+df = foehn.load("climate_scenarios", station="ABE")
+```
+
 ---
 
 ## Metadata

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -25,12 +25,16 @@ from foehn.collections import (
     GRIB2_COLLECTIONS,
     NETCDF_COLLECTIONS,
     NO_GRANULARITY_COLLECTIONS,
+    PREAMBLE_CSV_COLLECTIONS,
 )
 from foehn.convert import (
     _parse_metadata_types,
+    add_forecast_local_timestamp,
     add_indoor_columns,
     convert_climate_scenarios_indoor_to_parquet,
+    convert_climate_scenarios_to_parquet,
     convert_to_parquet,
+    parse_climate_scenarios_csv,
     parse_csv_bytes,
     parse_indoor_filename,
 )
@@ -117,6 +121,8 @@ def to_parquet(
     parquet_dir = data_dir / "parquet"
     if dataset in CSV_ZIP_COLLECTIONS:
         failures = convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
+    elif dataset in PREAMBLE_CSV_COLLECTIONS:
+        failures = convert_climate_scenarios_to_parquet(bronze_dir, parquet_dir)
     else:
         failures = convert_to_parquet(dataset, bronze_dir, parquet_dir)
     if failures:
@@ -336,6 +342,74 @@ def _load_indoor(
     )
 
 
+def _load_climate_scenarios(
+    dataset: str,
+    *,
+    station: str | list[str] | None = None,
+    columns: list[str] | None = None,
+    drop_null: str | None = None,
+    sort: str | None = None,
+    limit: int | None = None,
+    workers: int = DEFAULT_WORKERS,
+) -> pl.DataFrame:
+    """Load CH2025 climate-scenario CSVs (metadata preamble + wide model table).
+
+    Dates are nominal (0001..0030 on a 365-day calendar), so the calendar-based
+    year/month/date filters do not apply here; ``sort`` orders lexically by the
+    string ``date`` column.
+    """
+    collection_id = COLLECTIONS[dataset]
+
+    station_filter: set[str] | None = None
+    if station is not None:
+        station_filter = {station.lower()} if isinstance(station, str) else {s.lower() for s in station}
+
+    items = get_collection_items(collection_id, verbose=False)
+    if station_filter is not None:
+        items = [item for item in items if item.get("id", "").lower() in station_filter]
+
+    hrefs: list[str] = []
+    for item in items:
+        for asset_info in item.get("assets", {}).values():
+            href = asset_info.get("href", "")
+            filename = href.split("?")[0].split("/")[-1]
+            if href.endswith(".csv") and "_meta_" not in filename:
+                hrefs.append(href)
+
+    if not hrefs:
+        raise ValueError(f"No climate-scenario CSVs found for {dataset!r} with station={station}.")
+
+    local = threading.local()
+
+    def _fetch(href: str) -> pl.DataFrame:
+        if not hasattr(local, "session"):
+            local.session = _retry_session(pool_maxsize=1)
+        validate_download_href(href)
+        resp = local.session.get(href, timeout=120)
+        resp.raise_for_status()
+        return parse_climate_scenarios_csv(resp.content, href.split("?")[0].split("/")[-1])
+
+    if len(hrefs) == 1 or workers <= 1:
+        frames = [_fetch(h) for h in hrefs]
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            frames = list(pool.map(_fetch, hrefs))
+
+    df = pl.concat(frames, how="diagonal_relaxed")
+
+    if drop_null and drop_null in df.columns:
+        df = df.filter(pl.col(drop_null).is_not_null())
+    if sort in ("asc", "desc"):
+        df = df.sort("date", descending=(sort == "desc"))
+    if columns:
+        keep = [c for c in ("station_abbr", "variable", "gwl", "date") if c in df.columns]
+        keep += [c for c in columns if c not in keep and c in df.columns]
+        df = df.select(keep)
+    if limit is not None:
+        df = df.head(limit)
+    return df
+
+
 def load(
     dataset: str,
     *,
@@ -428,6 +502,24 @@ def load(
             drop_null=drop_null,
             sort=sort,
             limit=limit,
+        )
+
+    if dataset in PREAMBLE_CSV_COLLECTIONS:
+        if frequency is not None:
+            raise ValueError(f"Dataset {dataset!r} does not support frequency filtering.")
+        if any(x is not None for x in (year, month, date_from, date_to)):
+            raise ValueError(
+                f"Dataset {dataset!r} uses nominal 30-year dates (0001..0030); "
+                "year/month/date_from/date_to filters are not supported."
+            )
+        return _load_climate_scenarios(
+            dataset,
+            station=station,
+            columns=columns,
+            drop_null=drop_null,
+            sort=sort,
+            limit=limit,
+            workers=workers,
         )
 
     if time_slice is None:
@@ -537,6 +629,10 @@ def load(
             frames = list(pool.map(_fetch, csv_hrefs))
 
     df = pl.concat(frames, how="diagonal_relaxed")
+
+    # forecast_local has no reference_timestamp; derive it from the compact Date column.
+    if dataset == "forecast_local":
+        df = add_forecast_local_timestamp(df)
 
     return _apply_post_filters(
         df,

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -13,6 +13,7 @@ from foehn.client import (
     DEFAULT_WORKERS,
     DownloadResult,
     _retry_session,
+    download_climate_scenarios_indoor,
     download_collection,
     download_metadata,
 )
@@ -25,7 +26,14 @@ from foehn.collections import (
     NETCDF_COLLECTIONS,
     NO_GRANULARITY_COLLECTIONS,
 )
-from foehn.convert import _parse_metadata_types, convert_to_parquet, parse_csv_bytes
+from foehn.convert import (
+    _parse_metadata_types,
+    add_indoor_columns,
+    convert_climate_scenarios_indoor_to_parquet,
+    convert_to_parquet,
+    parse_csv_bytes,
+    parse_indoor_filename,
+)
 from foehn.stac import get_collection_items, get_collection_metadata
 
 
@@ -66,14 +74,13 @@ def download(
         raise ValueError(f"Unknown dataset: {dataset!r}. Use list_datasets() to see available datasets.")
     if dataset in GRIB2_COLLECTIONS or dataset in NETCDF_COLLECTIONS:
         raise ValueError(f"Dataset {dataset!r} is a binary/grid dataset. Use the CLI with --grids instead.")
-    if dataset in CSV_ZIP_COLLECTIONS:
-        raise ValueError(
-            f"Dataset {dataset!r} is a zipped multi-CSV collection. Download it with the CLI: foehn download {dataset}"
-        )
 
     data_dir = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     bronze_dir = data_dir / "bronze"
     bronze_dir.mkdir(parents=True, exist_ok=True)
+
+    if dataset in CSV_ZIP_COLLECTIONS:
+        return download_climate_scenarios_indoor(bronze_dir, dataset)
 
     meta = download_metadata(dataset, bronze_dir, workers=workers)
     coll = download_collection(dataset, bronze_dir, data_types=time_slice or ["recent"], since=since, workers=workers)
@@ -104,15 +111,14 @@ def to_parquet(
     """
     if dataset not in COLLECTIONS:
         raise ValueError(f"Unknown dataset: {dataset!r}. Use list_datasets() to see available datasets.")
-    if dataset in CSV_ZIP_COLLECTIONS:
-        raise ValueError(
-            f"Dataset {dataset!r} is a zipped multi-CSV collection. Use the CLI: foehn to-parquet {dataset}"
-        )
 
     data_dir = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     bronze_dir = data_dir / "bronze"
     parquet_dir = data_dir / "parquet"
-    failures = convert_to_parquet(dataset, bronze_dir, parquet_dir)
+    if dataset in CSV_ZIP_COLLECTIONS:
+        failures = convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
+    else:
+        failures = convert_to_parquet(dataset, bronze_dir, parquet_dir)
     if failures:
         raise RuntimeError(
             f"to_parquet({dataset!r}) failed: {failures} group(s) did not convert. See stdout for details."
@@ -215,6 +221,121 @@ def inventory(dataset: str) -> pl.DataFrame:
     )
 
 
+def _apply_post_filters(
+    df: pl.DataFrame,
+    *,
+    year: int | list[int] | None = None,
+    month: int | list[int] | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    drop_null: str | None = None,
+    sort: str | None = None,
+    columns: list[str] | None = None,
+    limit: int | None = None,
+    keep_cols: tuple[str, ...] = ("station_abbr", "reference_timestamp"),
+) -> pl.DataFrame:
+    """Apply the shared in-memory row/column filters used by load() variants."""
+    ts = "reference_timestamp"
+    if year is not None:
+        years = [year] if isinstance(year, int) else year
+        df = df.filter(pl.col(ts).dt.year().is_in(years))
+    if month is not None:
+        months = [month] if isinstance(month, int) else month
+        df = df.filter(pl.col(ts).dt.month().is_in(months))
+    if date_from is not None:
+        df = df.filter(pl.col(ts) >= pl.lit(date_from).str.to_datetime())
+    if date_to is not None:
+        df = df.filter(pl.col(ts) <= pl.lit(date_to).str.to_datetime())
+    if drop_null and drop_null in df.columns:
+        df = df.filter(pl.col(drop_null).is_not_null())
+    if sort in ("asc", "desc"):
+        df = df.sort(ts, descending=(sort == "desc"))
+    if columns:
+        keep = [c for c in keep_cols if c in df.columns]
+        keep += [c for c in columns if c not in keep and c in df.columns]
+        df = df.select(keep)
+    if limit is not None:
+        df = df.head(limit)
+    return df
+
+
+def _load_indoor(
+    dataset: str,
+    *,
+    station: str | list[str] | None = None,
+    year: int | list[int] | None = None,
+    month: int | list[int] | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    columns: list[str] | None = None,
+    drop_null: str | None = None,
+    sort: str | None = None,
+    limit: int | None = None,
+) -> pl.DataFrame:
+    """Load a zipped multi-CSV collection (indoor scenarios) into a DataFrame.
+
+    Unlike the per-station collections, this is a single archive, so the whole
+    ZIP is fetched and parsed in memory; ``station`` filters which member CSVs
+    are parsed, the rest of the filters apply to the combined frame.
+    """
+    import io
+    import zipfile
+
+    collection_id = COLLECTIONS[dataset]
+    items = get_collection_items(collection_id, require_csv=False, verbose=False)
+    zip_href = next(
+        (
+            asset_info.get("href", "")
+            for item in items
+            for asset_info in item.get("assets", {}).values()
+            if asset_info.get("href", "").split("?")[0].endswith(".zip")
+        ),
+        None,
+    )
+    if not zip_href:
+        raise ValueError(f"No .zip asset found for {dataset!r}.")
+
+    station_filter: set[str] | None = None
+    if station is not None:
+        station_filter = {station.lower()} if isinstance(station, str) else {s.lower() for s in station}
+
+    validate_download_href(zip_href)
+    resp = _retry_session().get(zip_href, timeout=300)
+    resp.raise_for_status()
+
+    frames: list[pl.DataFrame] = []
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        for name in zf.namelist():
+            if not name.endswith(".csv"):
+                continue
+            parsed = parse_indoor_filename(Path(name).stem)
+            if parsed is None:
+                continue
+            st, period, scenario, variant = parsed
+            if station_filter is not None and st.lower() not in station_filter:
+                continue
+            with zf.open(name) as fh:
+                frame = pl.read_csv(fh.read(), separator=",", infer_schema_length=10_000, truncate_ragged_lines=True)
+            frames.append(add_indoor_columns(frame, st, period, scenario, variant))
+
+    if not frames:
+        raise ValueError(f"No indoor data found for {dataset!r} with station={station}.")
+
+    df = pl.concat(frames, how="diagonal_relaxed")
+    return _apply_post_filters(
+        df,
+        year=year,
+        month=month,
+        date_from=date_from,
+        date_to=date_to,
+        drop_null=drop_null,
+        sort=sort,
+        columns=columns,
+        limit=limit,
+        keep_cols=("station_abbr", "reference_timestamp", "period", "scenario", "variant"),
+    )
+
+
 def load(
     dataset: str,
     *,
@@ -294,9 +415,19 @@ def load(
     if dataset in GRIB2_COLLECTIONS or dataset in NETCDF_COLLECTIONS:
         raise ValueError(f"Dataset {dataset!r} is a binary/grid dataset and cannot be loaded as a DataFrame.")
     if dataset in CSV_ZIP_COLLECTIONS:
-        raise ValueError(
-            f"Dataset {dataset!r} is a zipped multi-CSV collection. Download it with the CLI "
-            f"(foehn download {dataset}) and read the Parquet output; in-memory load() is not supported."
+        if frequency is not None:
+            raise ValueError(f"Dataset {dataset!r} does not support frequency filtering.")
+        return _load_indoor(
+            dataset,
+            station=station,
+            year=year,
+            month=month,
+            date_from=date_from,
+            date_to=date_to,
+            columns=columns,
+            drop_null=drop_null,
+            sort=sort,
+            limit=limit,
         )
 
     if time_slice is None:
@@ -407,27 +538,14 @@ def load(
 
     df = pl.concat(frames, how="diagonal_relaxed")
 
-    # Post-load filters.
-    ts = "reference_timestamp"
-    if year is not None:
-        years = [year] if isinstance(year, int) else year
-        df = df.filter(pl.col(ts).dt.year().is_in(years))
-    if month is not None:
-        months = [month] if isinstance(month, int) else month
-        df = df.filter(pl.col(ts).dt.month().is_in(months))
-    if date_from is not None:
-        df = df.filter(pl.col(ts) >= pl.lit(date_from).str.to_datetime())
-    if date_to is not None:
-        df = df.filter(pl.col(ts) <= pl.lit(date_to).str.to_datetime())
-    if drop_null and drop_null in df.columns:
-        df = df.filter(pl.col(drop_null).is_not_null())
-    if sort in ("asc", "desc"):
-        df = df.sort(ts, descending=(sort == "desc"))
-    if columns:
-        keep = ["station_abbr", "reference_timestamp"]
-        keep += [c for c in columns if c not in keep and c in df.columns]
-        df = df.select(keep)
-    if limit is not None:
-        df = df.head(limit)
-
-    return df
+    return _apply_post_filters(
+        df,
+        year=year,
+        month=month,
+        date_from=date_from,
+        date_to=date_to,
+        drop_null=drop_null,
+        sort=sort,
+        columns=columns,
+        limit=limit,
+    )

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -19,6 +19,7 @@ from foehn.client import (
 from foehn.collections import (
     COLLECTION_META,
     COLLECTIONS,
+    CSV_ZIP_COLLECTIONS,
     FORECAST_CSV_COLLECTIONS,
     GRIB2_COLLECTIONS,
     NETCDF_COLLECTIONS,
@@ -65,6 +66,10 @@ def download(
         raise ValueError(f"Unknown dataset: {dataset!r}. Use list_datasets() to see available datasets.")
     if dataset in GRIB2_COLLECTIONS or dataset in NETCDF_COLLECTIONS:
         raise ValueError(f"Dataset {dataset!r} is a binary/grid dataset. Use the CLI with --grids instead.")
+    if dataset in CSV_ZIP_COLLECTIONS:
+        raise ValueError(
+            f"Dataset {dataset!r} is a zipped multi-CSV collection. Download it with the CLI: foehn download {dataset}"
+        )
 
     data_dir = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     bronze_dir = data_dir / "bronze"
@@ -99,6 +104,10 @@ def to_parquet(
     """
     if dataset not in COLLECTIONS:
         raise ValueError(f"Unknown dataset: {dataset!r}. Use list_datasets() to see available datasets.")
+    if dataset in CSV_ZIP_COLLECTIONS:
+        raise ValueError(
+            f"Dataset {dataset!r} is a zipped multi-CSV collection. Use the CLI: foehn to-parquet {dataset}"
+        )
 
     data_dir = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     bronze_dir = data_dir / "bronze"
@@ -284,6 +293,11 @@ def load(
         raise ValueError(f"Unknown dataset: {dataset!r}. Use list_datasets() to see available datasets.")
     if dataset in GRIB2_COLLECTIONS or dataset in NETCDF_COLLECTIONS:
         raise ValueError(f"Dataset {dataset!r} is a binary/grid dataset and cannot be loaded as a DataFrame.")
+    if dataset in CSV_ZIP_COLLECTIONS:
+        raise ValueError(
+            f"Dataset {dataset!r} is a zipped multi-CSV collection. Download it with the CLI "
+            f"(foehn download {dataset}) and read the Parquet output; in-memory load() is not supported."
+        )
 
     if time_slice is None:
         time_slice = ["recent"]

--- a/src/foehn/cli.py
+++ b/src/foehn/cli.py
@@ -23,10 +23,12 @@ from foehn.collections import (
     CSV_ZIP_COLLECTIONS,
     GRIB2_COLLECTIONS,
     NETCDF_COLLECTIONS,
+    PREAMBLE_CSV_COLLECTIONS,
 )
 from foehn.convert import (
     convert_climate_normals_to_parquet,
     convert_climate_scenarios_indoor_to_parquet,
+    convert_climate_scenarios_to_parquet,
     convert_to_parquet,
 )
 
@@ -150,7 +152,10 @@ def cmd_download(args: argparse.Namespace) -> None:
             download_metadata(ds, bronze_dir, workers=workers)
             download_collection(ds, bronze_dir, data_types=time_slices, since=since, workers=workers)
             if not args.no_parquet:
-                failures += convert_to_parquet(ds, bronze_dir, parquet_dir)
+                if ds in PREAMBLE_CSV_COLLECTIONS:
+                    failures += convert_climate_scenarios_to_parquet(bronze_dir, parquet_dir)
+                else:
+                    failures += convert_to_parquet(ds, bronze_dir, parquet_dir)
 
     # C6 climate normals (ZIP from opendata.swiss, not STAC)
     if not args.datasets:
@@ -190,6 +195,9 @@ def cmd_to_parquet(args: argparse.Namespace) -> None:
             continue
         if ds in CSV_ZIP_COLLECTIONS:
             failures += convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
+            continue
+        if ds in PREAMBLE_CSV_COLLECTIONS:
+            failures += convert_climate_scenarios_to_parquet(bronze_dir, parquet_dir)
             continue
         failures += convert_to_parquet(ds, bronze_dir, parquet_dir)
 

--- a/src/foehn/cli.py
+++ b/src/foehn/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from foehn.api import inventory, list_datasets, parameters, stations
 from foehn.client import (
     download_climate_normals_zip,
+    download_climate_scenarios_indoor,
     download_collection,
     download_grib2,
     download_metadata,
@@ -19,10 +20,15 @@ from foehn.client import (
 )
 from foehn.collections import (
     COLLECTIONS,
+    CSV_ZIP_COLLECTIONS,
     GRIB2_COLLECTIONS,
     NETCDF_COLLECTIONS,
 )
-from foehn.convert import convert_climate_normals_to_parquet, convert_to_parquet
+from foehn.convert import (
+    convert_climate_normals_to_parquet,
+    convert_climate_scenarios_indoor_to_parquet,
+    convert_to_parquet,
+)
 
 
 def _resolve_data_dir(args_data_dir: Path | None) -> Path:
@@ -136,6 +142,10 @@ def cmd_download(args: argparse.Namespace) -> None:
             download_grib2(ds, bronze_dir, since=since, workers=workers)
         elif ds in NETCDF_COLLECTIONS:
             download_netcdf(ds, bronze_dir, since=since, workers=workers)
+        elif ds in CSV_ZIP_COLLECTIONS:
+            download_climate_scenarios_indoor(bronze_dir, ds, force=full_refresh)
+            if not args.no_parquet:
+                failures += convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
         else:
             download_metadata(ds, bronze_dir, workers=workers)
             download_collection(ds, bronze_dir, data_types=time_slices, since=since, workers=workers)
@@ -177,6 +187,9 @@ def cmd_to_parquet(args: argparse.Namespace) -> None:
     failures = 0
     for ds in datasets:
         if ds in GRIB2_COLLECTIONS or ds in NETCDF_COLLECTIONS:
+            continue
+        if ds in CSV_ZIP_COLLECTIONS:
+            failures += convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
             continue
         failures += convert_to_parquet(ds, bronze_dir, parquet_dir)
 

--- a/src/foehn/client.py
+++ b/src/foehn/client.py
@@ -521,3 +521,63 @@ def download_climate_normals_zip(output_dir: Path, force: bool = False) -> Downl
         print(f"  Extracted {len(zf.namelist())} files", flush=True)
 
     return DownloadResult(total_assets=1, downloaded=1, skipped=0, filenames=["normwerte.zip"])
+
+
+# --- Indoor climate scenarios ZIP (single .csv.zip of per-station CSVs) ---
+
+
+def download_climate_scenarios_indoor(
+    output_dir: Path,
+    collection_key: str = "climate_scenarios_indoor",
+    force: bool = False,
+) -> DownloadResult:
+    """Download and extract the indoor climate scenarios ZIP.
+
+    The collection ships a single ``.csv.zip`` (per-station, per-scenario hourly
+    CSVs) rather than individual STAC CSV assets, so it needs its own download
+    path. The archive is fetched from the STAC API and its members extracted to
+    ``output_dir/<collection_key>/``.
+    """
+    collection_id = COLLECTIONS[collection_key]
+    out_dir = output_dir / collection_key
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not force and any(out_dir.glob("*.csv")):
+        print(f"\n  {collection_key} already extracted — skipping", flush=True)
+        return DownloadResult(total_assets=1, downloaded=0, skipped=1, filenames=[])
+
+    items = get_collection_items(collection_id, require_csv=False, verbose=False)
+    zip_href = next(
+        (
+            asset_info.get("href", "")
+            for item in items
+            for asset_info in item.get("assets", {}).values()
+            if asset_info.get("href", "").split("?")[0].endswith(".zip")
+        ),
+        None,
+    )
+    if not zip_href:
+        print(f"  No .zip asset found for {collection_key}", flush=True)
+        return DownloadResult()
+
+    print(f"\n{'=' * 60}", flush=True)
+    print(f"Indoor scenarios ({collection_id}): downloading ZIP", flush=True)
+    print(f"{'=' * 60}", flush=True)
+
+    validate_download_href(zip_href)
+    zip_path = out_dir / zip_href.split("?")[0].split("/")[-1]
+    resp = _retry_session().get(zip_href, timeout=300)
+    resp.raise_for_status()
+    zip_path.write_bytes(resp.content)
+    print(f"  Downloaded: {zip_path.name} ({len(resp.content) / 1e6:.1f} MB)", flush=True)
+
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        resolved_out_dir = out_dir.resolve()
+        for member in zf.infolist():
+            target = (resolved_out_dir / member.filename).resolve()
+            if not str(target).startswith(str(resolved_out_dir) + "/"):
+                raise ValueError(f"Unsafe path in ZIP: {member.filename!r}")
+        zf.extractall(out_dir)
+        print(f"  Extracted {len(zf.namelist())} files", flush=True)
+
+    return DownloadResult(total_assets=1, downloaded=1, skipped=0, filenames=[zip_path.name])

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -312,8 +312,8 @@ COLLECTION_META: dict[str, dict] = {
         "category": "C",
         "subcategory": "C",
         "description": "Indoor climate scenarios",
-        "format": "NetCDF",
-        "frequencies": [],
+        "format": "CSV+ZIP",
+        "frequencies": ["h"],
         "time_slices": [],
     },
     # ── D: Radar data ────────────────────────────────────────────────────────
@@ -407,6 +407,13 @@ NETCDF_COLLECTIONS = {
     "hail_hazard_20y",
     "hail_hazard_50y",
     "hail_hazard_100y",
+}
+
+# Tabular collections delivered as a single ZIP of CSVs (not per-station STAC
+# assets), with their own separator/timestamp layout. Like the C6 climate
+# normals, these get a bespoke download+convert path rather than the standard
+# CSV flow, and are not exposed through the in-memory load() API.
+CSV_ZIP_COLLECTIONS = {
     "climate_scenarios_indoor",
 }
 

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -412,9 +412,18 @@ NETCDF_COLLECTIONS = {
 # Tabular collections delivered as a single ZIP of CSVs (not per-station STAC
 # assets), with their own separator/timestamp layout. Like the C6 climate
 # normals, these get a bespoke download+convert path rather than the standard
-# CSV flow, and are not exposed through the in-memory load() API.
+# CSV flow.
 CSV_ZIP_COLLECTIONS = {
     "climate_scenarios_indoor",
+}
+
+# CSV collections whose files carry a multi-row "KEY;VALUE" metadata preamble
+# before the real "DATE;<model>;..." table (CH2025 climate scenarios). The
+# standard reader would treat the preamble as the header, so these need a
+# preamble-skipping parser. Downloads are standard per-file CSVs; only the
+# parse differs.
+PREAMBLE_CSV_COLLECTIONS = {
+    "climate_scenarios",
 }
 
 

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -239,6 +239,39 @@ def convert_to_parquet(collection_key: str, bronze_dir: Path, parquet_dir: Path)
     return failed
 
 
+_INDOOR_TIME_COLS = ["time.yy", "time.mm", "time.dd", "time.hh"]
+
+
+def parse_indoor_filename(stem: str) -> tuple[str, str, str, str] | None:
+    """Parse an indoor scenario filename into (station, period, scenario, variant).
+
+    Data files are ``{station}_{period}_{scenario}_{variant}`` with a 4-digit
+    year as the period. Returns None for anything else (e.g. the archive's
+    metadata CSV), so callers can skip non-data files.
+    """
+    parts = stem.split("_")
+    if len(parts) < 4 or not parts[1].isdigit():
+        return None
+    return parts[0], parts[1], parts[2], "_".join(parts[3:])
+
+
+def add_indoor_columns(frame, station: str, period: str, scenario: str, variant: str):
+    """Add reference_timestamp + filename-derived columns and drop the raw time
+    columns. Works on both a LazyFrame (scan_csv) and a DataFrame (read_csv)."""
+    return frame.with_columns(
+        pl.datetime(
+            pl.col("time.yy"),
+            pl.col("time.mm"),
+            pl.col("time.dd"),
+            hour=pl.col("time.hh"),
+        ).alias("reference_timestamp"),
+        pl.lit(station).alias("station_abbr"),
+        pl.lit(period).alias("period"),
+        pl.lit(scenario).alias("scenario"),
+        pl.lit(variant).alias("variant"),
+    ).drop(_INDOOR_TIME_COLS)
+
+
 def convert_climate_scenarios_indoor_to_parquet(bronze_dir: Path, parquet_dir: Path) -> int:
     """Convert extracted indoor climate scenario CSVs to a single Parquet file.
 
@@ -263,35 +296,21 @@ def convert_climate_scenarios_indoor_to_parquet(bronze_dir: Path, parquet_dir: P
             return 0
 
     print(f"Converting climate_scenarios_indoor to Parquet ({len(csv_files)} files)...", flush=True)
-    time_cols = ["time.yy", "time.mm", "time.dd", "time.hh"]
     frames: list[pl.LazyFrame] = []
     skipped = 0
     for f in csv_files:
-        parts = f.stem.split("_")
-        # Data files are {station}_{period}_{scenario}_{variant} with a 4-digit
-        # year as the period. The archive also ships a metadata CSV that does not
-        # match — skip non-data files rather than treating them as failures.
-        if len(parts) < 4 or not parts[1].isdigit():
+        parsed = parse_indoor_filename(f.stem)
+        if parsed is None:
             skipped += 1
             print(f"  Skipping non-data file: {f.name}", flush=True)
             continue
-        station, period, scenario = parts[0], parts[1], parts[2]
-        variant = "_".join(parts[3:]) if len(parts) > 3 else ""
-        lf = (
-            pl.scan_csv(f, separator=",", infer_schema_length=10_000, truncate_ragged_lines=True)
-            .with_columns(
-                pl.datetime(
-                    pl.col("time.yy"),
-                    pl.col("time.mm"),
-                    pl.col("time.dd"),
-                    hour=pl.col("time.hh"),
-                ).alias("reference_timestamp"),
-                pl.lit(station).alias("station_abbr"),
-                pl.lit(period).alias("period"),
-                pl.lit(scenario).alias("scenario"),
-                pl.lit(variant).alias("variant"),
-            )
-            .drop(time_cols)
+        station, period, scenario, variant = parsed
+        lf = add_indoor_columns(
+            pl.scan_csv(f, separator=",", infer_schema_length=10_000, truncate_ragged_lines=True),
+            station,
+            period,
+            scenario,
+            variant,
         )
         frames.append(lf)
 

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -121,6 +121,22 @@ def parse_csv_bytes(
         raise last_err from None
 
 
+def add_forecast_local_timestamp(frame):
+    """Add a parsed reference_timestamp from forecast_local's compact Date column.
+
+    forecast_local CSVs carry ``point_id;point_type_id;Date;<param>`` where Date
+    is ``YYYYMMDDHHMM`` (e.g. 202605202100) and there is no reference_timestamp.
+    Works on both a LazyFrame and a DataFrame; a no-op if Date is absent or a
+    reference_timestamp already exists.
+    """
+    cols = frame.collect_schema().names() if isinstance(frame, pl.LazyFrame) else frame.columns
+    if "Date" not in cols or "reference_timestamp" in cols:
+        return frame
+    return frame.with_columns(
+        pl.col("Date").cast(pl.Utf8).str.to_datetime("%Y%m%d%H%M", strict=False).alias("reference_timestamp")
+    )
+
+
 def convert_to_parquet(collection_key: str, bronze_dir: Path, parquet_dir: Path) -> int:
     """Convert all CSVs in a collection's bronze folder to combined Parquet files.
 
@@ -209,7 +225,10 @@ def convert_to_parquet(collection_key: str, bronze_dir: Path, parquet_dir: Path)
                         )
                         for f in files
                     ]
-                    pl.concat(lazy_frames, how="diagonal_relaxed").sink_parquet(parquet_path, compression="zstd")
+                    combined = pl.concat(lazy_frames, how="diagonal_relaxed")
+                    if collection_key == "forecast_local":
+                        combined = add_forecast_local_timestamp(combined)
+                    combined.sink_parquet(parquet_path, compression="zstd")
                     break
                 except (pl.exceptions.ComputeError, pl.exceptions.SchemaError) as e:
                     m = _COL_RE.search(str(e))
@@ -325,6 +344,86 @@ def convert_climate_scenarios_indoor_to_parquet(bronze_dir: Path, parquet_dir: P
 
     print(f"  Done: wrote {out_path.name} ({len(frames)} files, {skipped} non-data skipped)", flush=True)
     return 0
+
+
+def parse_climate_scenarios_csv(content: bytes | str, filename: str) -> pl.DataFrame:
+    """Parse a CH2025 climate-scenario CSV into a wide model table.
+
+    These files carry a multi-row ``KEY;VALUE`` metadata preamble before the
+    real ``DATE;<model>;<model>;...`` header. We skip the preamble, read the
+    table, and tag rows with station/variable/gwl parsed from the filename
+    (``ogd-climate-scenarios-ch2025_{station}_{variable}_{gwl}``). The DATE
+    column is kept as a string because it encodes a nominal 30-year period
+    (0001-01-01 … 0030-12-31 on a 365-day calendar), not real calendar dates.
+    """
+    text = content.decode("utf-8-sig", errors="replace") if isinstance(content, bytes) else content
+    lines = text.splitlines()
+    header_idx = next((i for i, line in enumerate(lines) if line.startswith("DATE;")), None)
+    if header_idx is None:
+        raise ValueError(f"No 'DATE;' data header found in {filename!r}")
+
+    table = "\n".join(lines[header_idx:])
+    df = pl.read_csv(
+        io.BytesIO(table.encode("utf-8")),
+        separator=";",
+        infer_schema_length=20_000,
+        truncate_ragged_lines=True,
+    ).rename({"DATE": "date"})
+
+    stem = filename.rsplit("/", 1)[-1]
+    stem = stem[:-4] if stem.endswith(".csv") else stem
+    parts = stem.split("_")
+    station, variable, gwl = parts[-3], parts[-2], parts[-1]
+
+    df = df.with_columns(
+        pl.lit(station).alias("station_abbr"),
+        pl.lit(variable).alias("variable"),
+        pl.lit(gwl).alias("gwl"),
+    )
+    front = ["station_abbr", "variable", "gwl", "date"]
+    return df.select(front + [c for c in df.columns if c not in front])
+
+
+def convert_climate_scenarios_to_parquet(bronze_dir: Path, parquet_dir: Path) -> int:
+    """Convert CH2025 climate-scenario CSVs (with metadata preamble) to one Parquet."""
+    csv_dir = bronze_dir / "climate_scenarios"
+    out_dir = parquet_dir / "climate_scenarios"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_files = sorted(f for f in csv_dir.glob("*.csv") if "_meta_" not in f.name)
+    if not csv_files:
+        return 0
+
+    out_path = out_dir / "climate_scenarios.parquet"
+    if out_path.exists():
+        out_mtime = out_path.stat().st_mtime
+        if all(f.stat().st_mtime <= out_mtime for f in csv_files):
+            print("Converting climate_scenarios to Parquet:\n  up-to-date — skipping", flush=True)
+            return 0
+
+    def _safe_parse(path: Path) -> pl.DataFrame | None:
+        try:
+            return parse_climate_scenarios_csv(path.read_bytes(), path.name)
+        except Exception as e:
+            print(f"  FAIL {path.name}: {e}", flush=True)
+            return None
+
+    print(f"Converting climate_scenarios to Parquet ({len(csv_files)} files)...", flush=True)
+    parsed = [_safe_parse(f) for f in csv_files]
+    frames = [df for df in parsed if df is not None]
+    failed = sum(1 for df in parsed if df is None)
+
+    if not frames:
+        return failed
+
+    try:
+        pl.concat(frames, how="diagonal_relaxed").write_parquet(out_path, compression="zstd")
+    except Exception as e:
+        print(f"  FAIL: {e}", flush=True)
+        return failed + 1
+
+    print(f"  Done: wrote {out_path.name} ({len(frames)} files)", flush=True)
+    return failed
 
 
 def convert_climate_normals_to_parquet(bronze_dir: Path, parquet_dir: Path) -> int:

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -239,6 +239,75 @@ def convert_to_parquet(collection_key: str, bronze_dir: Path, parquet_dir: Path)
     return failed
 
 
+def convert_climate_scenarios_indoor_to_parquet(bronze_dir: Path, parquet_dir: Path) -> int:
+    """Convert extracted indoor climate scenario CSVs to a single Parquet file.
+
+    Each CSV is per-station/per-scenario hourly data: comma-separated, with the
+    timestamp split across time.yy/mm/dd/hh. The filename encodes
+    {station}_{period}_{scenario}_{variant}, which become columns alongside a
+    synthesised reference_timestamp. All files are concatenated into one Parquet.
+    """
+    csv_dir = bronze_dir / "climate_scenarios_indoor"
+    out_dir = parquet_dir / "climate_scenarios_indoor"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_files = sorted(csv_dir.glob("*.csv"))
+    if not csv_files:
+        return 0
+
+    out_path = out_dir / "climate_scenarios_indoor.parquet"
+    if out_path.exists():
+        out_mtime = out_path.stat().st_mtime
+        if all(f.stat().st_mtime <= out_mtime for f in csv_files):
+            print("Converting climate_scenarios_indoor to Parquet:\n  up-to-date — skipping", flush=True)
+            return 0
+
+    print(f"Converting climate_scenarios_indoor to Parquet ({len(csv_files)} files)...", flush=True)
+    time_cols = ["time.yy", "time.mm", "time.dd", "time.hh"]
+    frames: list[pl.LazyFrame] = []
+    skipped = 0
+    for f in csv_files:
+        parts = f.stem.split("_")
+        # Data files are {station}_{period}_{scenario}_{variant} with a 4-digit
+        # year as the period. The archive also ships a metadata CSV that does not
+        # match — skip non-data files rather than treating them as failures.
+        if len(parts) < 4 or not parts[1].isdigit():
+            skipped += 1
+            print(f"  Skipping non-data file: {f.name}", flush=True)
+            continue
+        station, period, scenario = parts[0], parts[1], parts[2]
+        variant = "_".join(parts[3:]) if len(parts) > 3 else ""
+        lf = (
+            pl.scan_csv(f, separator=",", infer_schema_length=10_000, truncate_ragged_lines=True)
+            .with_columns(
+                pl.datetime(
+                    pl.col("time.yy"),
+                    pl.col("time.mm"),
+                    pl.col("time.dd"),
+                    hour=pl.col("time.hh"),
+                ).alias("reference_timestamp"),
+                pl.lit(station).alias("station_abbr"),
+                pl.lit(period).alias("period"),
+                pl.lit(scenario).alias("scenario"),
+                pl.lit(variant).alias("variant"),
+            )
+            .drop(time_cols)
+        )
+        frames.append(lf)
+
+    if not frames:
+        return 0
+
+    try:
+        pl.concat(frames, how="diagonal_relaxed").sink_parquet(out_path, compression="zstd")
+    except Exception as e:
+        print(f"  FAIL: {e}", flush=True)
+        return 1
+
+    print(f"  Done: wrote {out_path.name} ({len(frames)} files, {skipped} non-data skipped)", flush=True)
+    return 0
+
+
 def convert_climate_normals_to_parquet(bronze_dir: Path, parquet_dir: Path) -> int:
     """Convert C6 climate normals TXT files to Parquet.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Tests for the public Python API."""
 
+import io
+import zipfile
 from unittest.mock import MagicMock, patch
 
 import polars as pl
@@ -65,19 +67,78 @@ def test_download_netcdf_dataset_raises():
         download("surface_derived_grid")
 
 
-def test_download_indoor_csv_zip_raises():
-    with pytest.raises(ValueError, match="zipped multi-CSV"):
-        download("climate_scenarios_indoor")
+_INDOOR_CSV = "time.yy,time.mm,time.dd,time.hh,tre200h0,ure200h0\n2035,1,1,0,0.3,94.5\n2035,1,1,1,-0.2,94.6\n"
 
 
-def test_to_parquet_indoor_csv_zip_raises():
-    with pytest.raises(ValueError, match="zipped multi-CSV"):
-        to_parquet("climate_scenarios_indoor")
+def _make_indoor_zip(data_names):
+    """Build an in-memory indoor .csv.zip with the given data CSVs + a metadata file."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for n in data_names:
+            zf.writestr(n, _INDOOR_CSV)
+        zf.writestr("Klimaszenarien-Raumklima_Metadata.csv", "a,b\n1,2\n")
+    return buf.getvalue()
 
 
-def test_load_indoor_csv_zip_raises():
-    with pytest.raises(ValueError, match="zipped multi-CSV"):
-        load("climate_scenarios_indoor")
+@patch("foehn.api.download_climate_scenarios_indoor")
+def test_download_indoor_routes_to_handler(mock_dl, tmp_path):
+    from foehn.client import DownloadResult
+
+    mock_dl.return_value = DownloadResult(total_assets=1, downloaded=1)
+    res = download("climate_scenarios_indoor", data_dir=tmp_path)
+    mock_dl.assert_called_once_with(tmp_path / "bronze", "climate_scenarios_indoor")
+    assert res.downloaded == 1
+
+
+@patch("foehn.api.convert_climate_scenarios_indoor_to_parquet")
+def test_to_parquet_indoor_routes_to_converter(mock_conv, tmp_path):
+    mock_conv.return_value = 0
+    to_parquet("climate_scenarios_indoor", data_dir=tmp_path)
+    mock_conv.assert_called_once_with(tmp_path / "bronze", tmp_path / "parquet")
+
+
+@patch("foehn.api.convert_climate_scenarios_indoor_to_parquet")
+def test_to_parquet_indoor_raises_on_failure(mock_conv, tmp_path):
+    mock_conv.return_value = 1
+    with pytest.raises(RuntimeError, match="did not convert"):
+        to_parquet("climate_scenarios_indoor", data_dir=tmp_path)
+
+
+def test_load_indoor_frequency_raises():
+    with pytest.raises(ValueError, match="does not support frequency"):
+        load("climate_scenarios_indoor", frequency="h")
+
+
+@patch("foehn.api.get_collection_items")
+@patch("foehn.api._retry_session")
+def test_load_indoor_returns_dataframe(mock_session, mock_items):
+    mock_items.return_value = [{"assets": {"d": {"href": "https://data.geo.admin.ch/x/raumklima.csv.zip"}}}]
+    zip_bytes = _make_indoor_zip(["ABO_2035_RCP85_DRY.csv", "AIG_2060_RCP26_DRY.csv"])
+    session = MagicMock()
+    session.get = MagicMock(return_value=_mock_response(zip_bytes))
+    mock_session.return_value = session
+
+    df = load("climate_scenarios_indoor")
+    assert isinstance(df, pl.DataFrame)
+    assert {"station_abbr", "period", "scenario", "variant", "reference_timestamp"} <= set(df.columns)
+    assert not any(c.startswith("time.") for c in df.columns)
+    assert set(df["station_abbr"].unique()) == {"ABO", "AIG"}
+    # 2 rows per data file × 2 files; the metadata CSV is skipped
+    assert len(df) == 4
+
+
+@patch("foehn.api.get_collection_items")
+@patch("foehn.api._retry_session")
+def test_load_indoor_station_filter(mock_session, mock_items):
+    mock_items.return_value = [{"assets": {"d": {"href": "https://data.geo.admin.ch/x/raumklima.csv.zip"}}}]
+    zip_bytes = _make_indoor_zip(["ABO_2035_RCP85_DRY.csv", "AIG_2060_RCP26_DRY.csv"])
+    session = MagicMock()
+    session.get = MagicMock(return_value=_mock_response(zip_bytes))
+    mock_session.return_value = session
+
+    df = load("climate_scenarios_indoor", station="ABO")
+    assert set(df["station_abbr"].unique()) == {"ABO"}
+    assert len(df) == 2
 
 
 @patch("foehn.api.download_collection")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,6 +141,65 @@ def test_load_indoor_station_filter(mock_session, mock_items):
     assert len(df) == 2
 
 
+# --- climate_scenarios (C8: metadata preamble + wide model table) ---
+
+_CS_CSV = (
+    "TITLE;X\nVARIABLE;Daily precipitation sum\nGWL;GWL1.5\n\n"
+    "DATE;MODEL_A;MODEL_B\n0001-01-01;0;24.2\n0001-01-02;1.5;0\n"
+)
+
+
+@patch("foehn.api.convert_climate_scenarios_to_parquet")
+def test_to_parquet_climate_scenarios_routes(mock_conv, tmp_path):
+    mock_conv.return_value = 0
+    to_parquet("climate_scenarios", data_dir=tmp_path)
+    mock_conv.assert_called_once_with(tmp_path / "bronze", tmp_path / "parquet")
+
+
+def test_load_climate_scenarios_year_filter_raises():
+    with pytest.raises(ValueError, match="nominal"):
+        load("climate_scenarios", year=2025)
+
+
+@patch("foehn.api.get_collection_items")
+@patch("foehn.api._retry_session")
+def test_load_climate_scenarios_returns_dataframe(mock_session, mock_items):
+    href = "https://data.geo.admin.ch/x/ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv"
+    mock_items.return_value = [{"id": "abe", "assets": {"d": {"href": href}}}]
+    session = MagicMock()
+    session.get = MagicMock(return_value=_mock_response(_CS_CSV))
+    mock_session.return_value = session
+
+    df = load("climate_scenarios")
+    assert isinstance(df, pl.DataFrame)
+    assert df.columns[:4] == ["station_abbr", "variable", "gwl", "date"]
+    assert df["station_abbr"][0] == "abe"
+    assert "MODEL_A" in df.columns
+    assert df["date"].to_list() == ["0001-01-01", "0001-01-02"]
+
+
+# --- forecast_local Date normalization ---
+
+_FORECAST_LOCAL_CSV = "point_id;point_type_id;Date;dkl010h0\n1;1;202605202100;282\n1;1;202605202200;315\n"
+
+
+@patch("foehn.api.get_collection_items")
+@patch("foehn.api.get_collection_metadata")
+@patch("foehn.api._retry_session")
+def test_load_forecast_local_adds_reference_timestamp(mock_session, mock_meta, mock_items):
+    mock_meta.return_value = {"assets": {}}
+    href = "https://data.geo.admin.ch/x/vnut12.lssw.202605210000.dkl010h0.csv"
+    mock_items.return_value = [{"id": "x", "properties": {"datetime": "2026-05-21"}, "assets": {"d": {"href": href}}}]
+    session = MagicMock()
+    session.get = MagicMock(return_value=_mock_response(_FORECAST_LOCAL_CSV))
+    mock_session.return_value = session
+
+    df = load("forecast_local")
+    assert "reference_timestamp" in df.columns
+    assert df["reference_timestamp"].dtype == pl.Datetime
+    assert df["reference_timestamp"][0].year == 2026
+
+
 @patch("foehn.api.download_collection")
 @patch("foehn.api.download_metadata")
 def test_download_calls_underlying_functions(mock_meta, mock_dl, tmp_path):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,6 +65,21 @@ def test_download_netcdf_dataset_raises():
         download("surface_derived_grid")
 
 
+def test_download_indoor_csv_zip_raises():
+    with pytest.raises(ValueError, match="zipped multi-CSV"):
+        download("climate_scenarios_indoor")
+
+
+def test_to_parquet_indoor_csv_zip_raises():
+    with pytest.raises(ValueError, match="zipped multi-CSV"):
+        to_parquet("climate_scenarios_indoor")
+
+
+def test_load_indoor_csv_zip_raises():
+    with pytest.raises(ValueError, match="zipped multi-CSV"):
+        load("climate_scenarios_indoor")
+
+
 @patch("foehn.api.download_collection")
 @patch("foehn.api.download_metadata")
 def test_download_calls_underlying_functions(mock_meta, mock_dl, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,10 @@ _PATCHES = [
     "foehn.cli.download_grib2",
     "foehn.cli.download_netcdf",
     "foehn.cli.download_climate_normals_zip",
+    "foehn.cli.download_climate_scenarios_indoor",
     "foehn.cli.convert_to_parquet",
     "foehn.cli.convert_climate_normals_to_parquet",
+    "foehn.cli.convert_climate_scenarios_indoor_to_parquet",
     "foehn.cli.save_last_run",
     "foehn.cli.load_last_run",
 ]
@@ -30,6 +32,7 @@ def _start_mocks():
     mocks["load_last_run"].return_value = None
     mocks["convert_to_parquet"].return_value = 0
     mocks["convert_climate_normals_to_parquet"].return_value = 0
+    mocks["convert_climate_scenarios_indoor_to_parquet"].return_value = 0
     return mocks, patchers
 
 
@@ -116,6 +119,13 @@ def test_default_runs_conversion(tmp_path):
     mocks = _run("download", [], tmp_path)
     mocks["convert_to_parquet"].assert_called()
     mocks["convert_climate_normals_to_parquet"].assert_called()
+
+
+def test_default_runs_indoor_handler(tmp_path):
+    """Indoor scenarios (CSV+ZIP) should be downloaded + converted in the default run."""
+    mocks = _run("download", [], tmp_path)
+    mocks["download_climate_scenarios_indoor"].assert_called()
+    mocks["convert_climate_scenarios_indoor_to_parquet"].assert_called()
 
 
 # --- full-refresh ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ _PATCHES = [
     "foehn.cli.convert_to_parquet",
     "foehn.cli.convert_climate_normals_to_parquet",
     "foehn.cli.convert_climate_scenarios_indoor_to_parquet",
+    "foehn.cli.convert_climate_scenarios_to_parquet",
     "foehn.cli.save_last_run",
     "foehn.cli.load_last_run",
 ]
@@ -33,6 +34,7 @@ def _start_mocks():
     mocks["convert_to_parquet"].return_value = 0
     mocks["convert_climate_normals_to_parquet"].return_value = 0
     mocks["convert_climate_scenarios_indoor_to_parquet"].return_value = 0
+    mocks["convert_climate_scenarios_to_parquet"].return_value = 0
     return mocks, patchers
 
 
@@ -126,6 +128,14 @@ def test_default_runs_indoor_handler(tmp_path):
     mocks = _run("download", [], tmp_path)
     mocks["download_climate_scenarios_indoor"].assert_called()
     mocks["convert_climate_scenarios_indoor_to_parquet"].assert_called()
+
+
+def test_default_runs_climate_scenarios_handler(tmp_path):
+    """climate_scenarios (preamble CSV) should use its bespoke converter, not convert_to_parquet."""
+    mocks = _run("download", [], tmp_path)
+    mocks["convert_climate_scenarios_to_parquet"].assert_called()
+    for call in mocks["convert_to_parquet"].call_args_list:
+        assert call[0][0] != "climate_scenarios"
 
 
 # --- full-refresh ---

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,6 +4,7 @@ from foehn.api import list_datasets
 from foehn.collections import (
     COLLECTION_META,
     COLLECTIONS,
+    CSV_ZIP_COLLECTIONS,
     FORECAST_CSV_COLLECTIONS,
     GRIB2_COLLECTIONS,
     NETCDF_COLLECTIONS,
@@ -21,14 +22,21 @@ def test_routing_sets_are_subsets_of_collections():
     assert keys >= FORECAST_CSV_COLLECTIONS
     assert keys >= GRIB2_COLLECTIONS
     assert keys >= NETCDF_COLLECTIONS
+    assert keys >= CSV_ZIP_COLLECTIONS
 
 
 def test_routing_sets_are_mutually_exclusive():
     """A collection should belong to at most one routing set."""
-    all_sets = [FORECAST_CSV_COLLECTIONS, GRIB2_COLLECTIONS, NETCDF_COLLECTIONS]
+    all_sets = [FORECAST_CSV_COLLECTIONS, GRIB2_COLLECTIONS, NETCDF_COLLECTIONS, CSV_ZIP_COLLECTIONS]
     for i, a in enumerate(all_sets):
         for b in all_sets[i + 1 :]:
             assert a.isdisjoint(b), f"Overlap between routing sets: {a & b}"
+
+
+def test_indoor_scenarios_is_csv_zip_not_netcdf():
+    assert "climate_scenarios_indoor" in CSV_ZIP_COLLECTIONS
+    assert "climate_scenarios_indoor" not in NETCDF_COLLECTIONS
+    assert COLLECTION_META["climate_scenarios_indoor"]["format"] == "CSV+ZIP"
 
 
 def test_collection_ids_are_unique():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -8,6 +8,7 @@ from foehn.collections import (
     FORECAST_CSV_COLLECTIONS,
     GRIB2_COLLECTIONS,
     NETCDF_COLLECTIONS,
+    PREAMBLE_CSV_COLLECTIONS,
 )
 
 
@@ -23,11 +24,18 @@ def test_routing_sets_are_subsets_of_collections():
     assert keys >= GRIB2_COLLECTIONS
     assert keys >= NETCDF_COLLECTIONS
     assert keys >= CSV_ZIP_COLLECTIONS
+    assert keys >= PREAMBLE_CSV_COLLECTIONS
 
 
 def test_routing_sets_are_mutually_exclusive():
     """A collection should belong to at most one routing set."""
-    all_sets = [FORECAST_CSV_COLLECTIONS, GRIB2_COLLECTIONS, NETCDF_COLLECTIONS, CSV_ZIP_COLLECTIONS]
+    all_sets = [
+        FORECAST_CSV_COLLECTIONS,
+        GRIB2_COLLECTIONS,
+        NETCDF_COLLECTIONS,
+        CSV_ZIP_COLLECTIONS,
+        PREAMBLE_CSV_COLLECTIONS,
+    ]
     for i, a in enumerate(all_sets):
         for b in all_sets[i + 1 :]:
             assert a.isdisjoint(b), f"Overlap between routing sets: {a & b}"
@@ -37,6 +45,12 @@ def test_indoor_scenarios_is_csv_zip_not_netcdf():
     assert "climate_scenarios_indoor" in CSV_ZIP_COLLECTIONS
     assert "climate_scenarios_indoor" not in NETCDF_COLLECTIONS
     assert COLLECTION_META["climate_scenarios_indoor"]["format"] == "CSV+ZIP"
+
+
+def test_climate_scenarios_is_preamble_csv():
+    assert "climate_scenarios" in PREAMBLE_CSV_COLLECTIONS
+    assert "climate_scenarios" not in NETCDF_COLLECTIONS
+    assert "climate_scenarios" not in CSV_ZIP_COLLECTIONS
 
 
 def test_collection_ids_are_unique():

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -9,9 +9,12 @@ import pytest
 from foehn.convert import (
     _load_metadata_types,
     _parse_metadata_types,
+    add_forecast_local_timestamp,
     convert_climate_normals_to_parquet,
     convert_climate_scenarios_indoor_to_parquet,
+    convert_climate_scenarios_to_parquet,
     convert_to_parquet,
+    parse_climate_scenarios_csv,
     parse_csv_bytes,
 )
 
@@ -290,3 +293,64 @@ def test_convert_indoor_scenarios_skips_metadata_file(tmp_path):
 
     df = pl.read_parquet(parquet_dir / "climate_scenarios_indoor" / "climate_scenarios_indoor.parquet")
     assert set(df["station_abbr"].unique()) == {"ABO"}
+
+
+# --- climate_scenarios C8 (metadata preamble + wide model table) ---
+
+_CS_CSV = (
+    "TITLE;Climate CH2025\n"
+    "VARIABLE;Daily precipitation sum\n"
+    "STATION_ABBR;ABE\n"
+    "GWL;GWL1.5\n"
+    "\n"
+    "DATE;MODEL_A;MODEL_B\n"
+    "0001-01-01;0;24.2\n"
+    "0001-01-02;1.5;0\n"
+)
+
+
+def test_parse_climate_scenarios_csv_skips_preamble():
+    df = parse_climate_scenarios_csv(_CS_CSV.encode("utf-8"), "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv")
+    assert df.columns[:4] == ["station_abbr", "variable", "gwl", "date"]
+    assert {"MODEL_A", "MODEL_B"} <= set(df.columns)
+    assert df["station_abbr"][0] == "abe"
+    assert df["variable"][0] == "pr"
+    assert df["gwl"][0] == "gwl1.5"
+    assert df["date"].to_list() == ["0001-01-01", "0001-01-02"]
+    assert df["MODEL_A"].dtype == pl.Float64
+    assert len(df) == 2
+
+
+def test_convert_climate_scenarios_to_parquet(tmp_path):
+    bronze_dir = tmp_path / "bronze"
+    cs_dir = bronze_dir / "climate_scenarios"
+    cs_dir.mkdir(parents=True)
+    (cs_dir / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv").write_text(_CS_CSV)
+    (cs_dir / "ogd-climate-scenarios-ch2025_ber_tas_gwl2.0.csv").write_text(_CS_CSV)
+
+    parquet_dir = tmp_path / "parquet"
+    failed = convert_climate_scenarios_to_parquet(bronze_dir, parquet_dir)
+    assert failed == 0
+
+    df = pl.read_parquet(parquet_dir / "climate_scenarios" / "climate_scenarios.parquet")
+    assert set(df["station_abbr"].unique()) == {"abe", "ber"}
+    assert set(df["variable"].unique()) == {"pr", "tas"}
+    assert set(df["gwl"].unique()) == {"gwl1.5", "gwl2.0"}
+    assert len(df) == 4
+
+
+# --- forecast_local Date -> reference_timestamp ---
+
+
+def test_add_forecast_local_timestamp():
+    df = pl.DataFrame({"point_id": [1], "Date": [202605202100], "dkl010h0": [282]})
+    out = add_forecast_local_timestamp(df)
+    assert "reference_timestamp" in out.columns
+    assert out["reference_timestamp"].dtype == pl.Datetime
+    ts = out["reference_timestamp"][0]
+    assert (ts.year, ts.month, ts.day, ts.hour) == (2026, 5, 20, 21)
+
+
+def test_add_forecast_local_timestamp_noop_without_date():
+    df = pl.DataFrame({"a": [1]})
+    assert add_forecast_local_timestamp(df).columns == ["a"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -10,6 +10,7 @@ from foehn.convert import (
     _load_metadata_types,
     _parse_metadata_types,
     convert_climate_normals_to_parquet,
+    convert_climate_scenarios_indoor_to_parquet,
     convert_to_parquet,
     parse_csv_bytes,
 )
@@ -233,3 +234,59 @@ def test_convert_climate_normals_handles_bad_file(tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert "FAIL" in out
+
+
+# --- indoor climate scenarios (zipped multi-CSV) ---
+
+_INDOOR_CSV = (
+    "time.yy,time.mm,time.dd,time.hh,tre200h0,ure200h0,skycover\n"
+    "2035,1,1,0,0.3,94.5,36\n"
+    "2035,1,1,1,-0.2,94.6,26\n"
+    "2035,1,1,2,-0.5,94.3,20\n"
+)
+
+
+def test_convert_indoor_scenarios_parses_filename_and_timestamp(tmp_path):
+    bronze_dir = tmp_path / "bronze"
+    indoor_dir = bronze_dir / "climate_scenarios_indoor"
+    indoor_dir.mkdir(parents=True)
+    (indoor_dir / "ABO_2035_RCP85_1in10-warmsummer.csv").write_text(_INDOOR_CSV)
+    (indoor_dir / "AIG_2060_RCP26_DRY.csv").write_text(_INDOOR_CSV)
+
+    parquet_dir = tmp_path / "parquet"
+    failed = convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
+    assert failed == 0
+
+    out = parquet_dir / "climate_scenarios_indoor" / "climate_scenarios_indoor.parquet"
+    assert out.exists()
+
+    df = pl.read_parquet(out)
+    # 3 rows per file × 2 files
+    assert len(df) == 6
+    # filename-derived columns + synthesised timestamp + dropped time.* cols
+    assert {"station_abbr", "period", "scenario", "variant", "reference_timestamp"} <= set(df.columns)
+    assert not any(c.startswith("time.") for c in df.columns)
+    assert set(df["station_abbr"].unique()) == {"ABO", "AIG"}
+    assert set(df["scenario"].unique()) == {"RCP85", "RCP26"}
+    assert "1in10-warmsummer" in set(df["variant"].unique())
+    assert df["reference_timestamp"].dtype == pl.Datetime
+
+
+def test_convert_indoor_scenarios_no_files_returns_zero(tmp_path):
+    assert convert_climate_scenarios_indoor_to_parquet(tmp_path / "bronze", tmp_path / "parquet") == 0
+
+
+def test_convert_indoor_scenarios_skips_metadata_file(tmp_path):
+    """The archive's non-data metadata CSV must be skipped, not counted as a failure."""
+    bronze_dir = tmp_path / "bronze"
+    indoor_dir = bronze_dir / "climate_scenarios_indoor"
+    indoor_dir.mkdir(parents=True)
+    (indoor_dir / "ABO_2035_RCP85_DRY.csv").write_text(_INDOOR_CSV)
+    (indoor_dir / "Klimaszenarien-Raumklima_Metadata.csv").write_text("foo,bar\n1,2\n")
+
+    parquet_dir = tmp_path / "parquet"
+    failed = convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
+    assert failed == 0
+
+    df = pl.read_parquet(parquet_dir / "climate_scenarios_indoor" / "climate_scenarios_indoor.parquet")
+    assert set(df["station_abbr"].unique()) == {"ABO"}


### PR DESCRIPTION
climate_scenarios_indoor was mislabeled as NetCDF but actually ships a single .csv.zip of per-station/per-scenario hourly CSVs. Recategorise it into a new CSV_ZIP_COLLECTIONS set (format CSV+ZIP) and add a bespoke download+convert path, mirroring the C6 climate normals handling.

download_climate_scenarios_indoor() fetches and extracts the archive; convert_climate_scenarios_indoor_to_parquet() parses each filename into station/period/scenario/variant columns, synthesises reference_timestamp from time.yy/mm/dd/hh, and writes one combined Parquet (skipping the archive's metadata CSV). The CLI download/to-parquet route it; the in-memory load()/download()/to_parquet() APIs reject it with guidance to use the CLI.