### PR TITLE
Remove 10 collections retired from the MeteoSwiss STAC API

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -65,14 +65,15 @@ GRIB2 forecast and analysis collections are large and require `--grids` to downl
 
 ## Hail hazard maps
 
-Static spatial reference grids showing expected hail grain size (cm) at different return periods. These are not categorised under A--E because they are static hazard assessments, not measured or forecasted time series -- they represent probabilistic climatological analyses published as fixed reference maps.
+MeteoSwiss retired the standalone `hail_hazard_*` collections; the hail grain size return-period grids are now assets on `radar_derived_grid` (C5), under its `archive-ch` item. Select one with `match`:
 
-| Key | Description | Format |
-|---|---|---|
-| `hail_hazard_10y` | Hail grain size -- 10-year return period | NetCDF / GeoTIFF (opt-in) |
-| `hail_hazard_20y` | Hail grain size -- 20-year return period | NetCDF / GeoTIFF (opt-in) |
-| `hail_hazard_50y` | Hail grain size -- 50-year return period | NetCDF / GeoTIFF (opt-in) |
-| `hail_hazard_100y` | Hail grain size -- 100-year return period | NetCDF / GeoTIFF (opt-in) |
+```python
+foehn.describe_grid("radar_derived_grid", match="returnperiod050yleha1")
+```
+
+Return periods are `002`, `005`, `010`, `020`, `030`, `050`, `070`, and `100` years, each in a `leha1` (grain size) and a `meshs` variant. The same item also carries hail-day grids (`haildays*`, 2 cm and 4 cm thresholds).
+
+Likewise, the per-parameter `climate_normals_*` map layers were retired -- those normals are assets on `climate_normals_grid` (C7), e.g. `match="tnormy9120"` for yearly temperature normals 1991--2020.
 
 ---
 

--- a/docs/grids.md
+++ b/docs/grids.md
@@ -34,9 +34,9 @@ whole `grids` install, not just GRIB2. `rechunk=` additionally needs `dask`
 All three install via `pip install "foehn[grids]"`.
 
 **NetCDF**: the spatial climate analyses (`surface_derived_grid`,
-`satellite_derived_grid`, `radar_derived_grid`), the `climate_normals_grid`
-and `climate_normals_*` reference grids, `climate_scenarios_grid`, and the
-`hail_hazard_*` maps.
+`satellite_derived_grid`, `radar_derived_grid` -- which also carries the hail
+return-period and hail-day grids), the `climate_normals_grid` reference grids,
+and `climate_scenarios_grid`.
 
 **GRIB2**: the forecasts `forecast_icon_ch1`, `forecast_icon_ch2`, and the
 analysis `analysis_kenda_ch1`. See [Forecasts (GRIB2)](#forecasts-grib2).
@@ -221,8 +221,8 @@ foehn.to_zarr("surface_derived_grid", match="tabsd")
 # -> data/meteoswiss/zarr/surface_derived_grid__tabsd.zarr  (distinct store)
 
 # Unfiltered keeps the bare name
-foehn.to_zarr("hail_hazard_50y")
-# -> data/meteoswiss/zarr/hail_hazard_50y.zarr
+foehn.to_zarr("climate_normals_grid")
+# -> data/meteoswiss/zarr/climate_normals_grid.zarr
 
 # Override the location explicitly
 foehn.to_zarr("surface_derived_grid", match="rhiresd", store="out/rain.zarr")

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -115,24 +115,17 @@ COLLECTIONS = {
     "radar_derived_grid": "ch.meteoschweiz.ogd-radar-derived-grid",  # C5 — Hail (days + return periods), radar-derived
     # C6 — Climate normals → downloaded separately as ZIP, see CLIMATE_NORMALS_ZIP_URL
     # C7 — Spatial climate normals (NetCDF/GeoTIFF, static reference grids)
-    # The OGD NetCDF normals grid is the unified successor to the per-parameter
-    # klimanormwerte-* GeoTIFF map layers below (temp/precip/sun + radiation/cloud).
+    # Supersedes the retired per-parameter klimanormwerte-* map layers: the same
+    # temp/precip/sun normals (1991-2020 and 1961-1990) are assets on this
+    # collection's single "ch" item, e.g. match="tnormy9120".
     "climate_normals_grid": "ch.meteoschweiz.ogd-climate-normals-grid",  # C7 — Spatial normals (NetCDF)
-    "climate_normals_precip_9120": "ch.meteoschweiz.klimanormwerte-niederschlag_aktuelle_periode",
-    "climate_normals_sun_9120": "ch.meteoschweiz.klimanormwerte-sonnenscheindauer_aktuelle_periode",
-    "climate_normals_temp_9120": "ch.meteoschweiz.klimanormwerte-temperatur_aktuelle_periode",
-    "climate_normals_precip_6190": "ch.meteoschweiz.klimanormwerte-niederschlag_1961_1990",
-    "climate_normals_sun_6190": "ch.meteoschweiz.klimanormwerte-sonnenscheindauer_1961_1990",
-    "climate_normals_temp_6190": "ch.meteoschweiz.klimanormwerte-temperatur_1961_1990",
     # C8 — Climate scenarios CH2025 local (CSV, no time-slice)
     "climate_scenarios": "ch.meteoschweiz.ogd-climate-scenarios-ch2025",
     # C9 — Climate scenarios CH2025 gridded (NetCDF, static)
     "climate_scenarios_grid": "ch.meteoschweiz.ogd-climate-scenarios-ch2025-grid",
-    # ── Hail hazard maps (NetCDF+ZIP, static reference grids) ────────────────────
-    "hail_hazard_10y": "ch.meteoschweiz.hagelgefaehrdung-korngroesse_10_jahre",
-    "hail_hazard_20y": "ch.meteoschweiz.hagelgefaehrdung-korngroesse_20_jahre",
-    "hail_hazard_50y": "ch.meteoschweiz.hagelgefaehrdung-korngroesse_50_jahre",
-    "hail_hazard_100y": "ch.meteoschweiz.hagelgefaehrdung-korngroesse_100_jahre",
+    # NOTE: the hagelgefaehrdung-korngroesse_* hazard maps were retired from the
+    # STAC API; their return-period grids are now assets on radar_derived_grid's
+    # "archive-ch" item, e.g. match="returnperiod050yleha1".
     # ── Indoor climate scenarios (ZIP, static) ───────────────────────────────────
     "climate_scenarios_indoor": "ch.meteoschweiz.klimaszenarien-raumklima",
     # ── D: Radar data (HDF5, no time-slice, opt-in via --grids) ─────────────────
@@ -264,54 +257,6 @@ COLLECTION_META: dict[str, dict] = {
         "frequencies": [],
         "time_slices": [],
     },
-    "climate_normals_precip_9120": {
-        "category": "C",
-        "subcategory": "C7",
-        "description": "Precipitation normals (1991-2020)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    "climate_normals_sun_9120": {
-        "category": "C",
-        "subcategory": "C7",
-        "description": "Sunshine normals (1991-2020)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    "climate_normals_temp_9120": {
-        "category": "C",
-        "subcategory": "C7",
-        "description": "Temperature normals (1991-2020)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    "climate_normals_precip_6190": {
-        "category": "C",
-        "subcategory": "C7",
-        "description": "Precipitation normals (1961-1990)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    "climate_normals_sun_6190": {
-        "category": "C",
-        "subcategory": "C7",
-        "description": "Sunshine normals (1961-1990)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    "climate_normals_temp_6190": {
-        "category": "C",
-        "subcategory": "C7",
-        "description": "Temperature normals (1961-1990)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
     # NOTE: collections whose filenames carry no granularity segment
     # (NO_GRANULARITY/CSV_ZIP) advertise no frequencies — the ``frequency``
     # filter is unsupported there, and this field doubles as its valid values.
@@ -327,39 +272,6 @@ COLLECTION_META: dict[str, dict] = {
         "category": "C",
         "subcategory": "C9",
         "description": "Climate scenarios CH2025 gridded",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    # ── Hail hazard maps ─────────────────────────────────────────────────────
-    "hail_hazard_10y": {
-        "category": "C",
-        "subcategory": "C",
-        "description": "Hail hazard map (10-year return period)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    "hail_hazard_20y": {
-        "category": "C",
-        "subcategory": "C",
-        "description": "Hail hazard map (20-year return period)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    "hail_hazard_50y": {
-        "category": "C",
-        "subcategory": "C",
-        "description": "Hail hazard map (50-year return period)",
-        "format": "NetCDF",
-        "frequencies": [],
-        "time_slices": [],
-    },
-    "hail_hazard_100y": {
-        "category": "C",
-        "subcategory": "C",
-        "description": "Hail hazard map (100-year return period)",
         "format": "NetCDF",
         "frequencies": [],
         "time_slices": [],
@@ -455,16 +367,6 @@ NETCDF_COLLECTIONS = {
     "radar_derived_grid",
     "climate_scenarios_grid",
     "climate_normals_grid",
-    "climate_normals_precip_9120",
-    "climate_normals_sun_9120",
-    "climate_normals_temp_9120",
-    "climate_normals_precip_6190",
-    "climate_normals_sun_6190",
-    "climate_normals_temp_6190",
-    "hail_hazard_10y",
-    "hail_hazard_20y",
-    "hail_hazard_50y",
-    "hail_hazard_100y",
 }
 
 # Tabular collections delivered as a single ZIP of CSVs (not per-station STAC

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -59,7 +59,7 @@ def test_ensure_netcdf_files_raises_when_no_nc_assets(mock_items, tmp_path):
         {"assets": {"b": {"href": "https://data.geo.admin.ch/x/bundle.zip"}}},
     ]
     with pytest.raises(ValueError, match=r"No \.nc assets"):
-        _ensure_grid_files("hail_hazard_10y", tmp_path / "bronze")
+        _ensure_grid_files("climate_normals_grid", tmp_path / "bronze")
 
 
 def test_ensure_netcdf_files_match_selects_subset_via_remote(tmp_path):
@@ -810,11 +810,11 @@ def test_to_zarr_with_noncf_time_reopens_cleanly(_mock_items, tmp_path):
             "x": [0, 1, 2],
         },
     )
-    out_dir = tmp_path / "bronze" / "climate_normals_temp_9120"
+    out_dir = tmp_path / "bronze" / "climate_normals_grid"
     out_dir.mkdir(parents=True)
     # netcdf4 engine preserves the non-CF units attribute on the time axis
     ds.to_netcdf(out_dir / "normals_yearly.nc", engine="netcdf4")
 
-    store = to_zarr("climate_normals_temp_9120", data_dir=tmp_path)
+    store = to_zarr("climate_normals_grid", data_dir=tmp_path)
     roundtrip = xr.open_zarr(store)  # default CF decode must not throw
     assert "TnormY" in roundtrip.data_vars


### PR DESCRIPTION
The hagelgefaehrdung-korngroesse_* and klimanormwerte-* collections now 404 on data.geo.admin.ch. Their data was folded into two existing collections:

- hail return periods -> radar_derived_grid, "archive-ch" item, as returnperiod{002..100}y{leha1,meshs} (a superset: 2/5/30/70y and a MESHS variant were added)
- temp/precip/sun normals -> climate_normals_grid, "ch" item, as {t,r,s}norm{m,y}{9120,6190}

Drop the dead keys from COLLECTIONS, COLLECTION_META and NETCDF_COLLECTIONS, and document the match= access pattern that replaces them. Two tests used these keys incidentally (any NetCDF collection / any grid key) and now use climate_normals_grid.

CLIMATE_NORMALS_ZIP_URL is unaffected - the station-based C6 normals ZIP is on the plain file server, not the STAC API, and still serves.