### PR TITLE
Fix empty forecast_local results by selecting the latest forecast run

### DIFF
--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -29,6 +29,7 @@ from foehn.collections import (
     NETCDF_COLLECTIONS,
     NO_GRANULARITY_COLLECTIONS,
     PREAMBLE_CSV_COLLECTIONS,
+    forecast_run_from_filename,
     time_slice_from_filename,
 )
 from foehn.convert import (
@@ -604,12 +605,12 @@ def load(
     if station_filter is not None:
         items = [item for item in items if item.get("id", "").lower() in station_filter]
 
+    # A forecast item is one *day*, not one forecast, and the newest one is empty
+    # until that day's runs publish — so keep all items and narrow to the newest
+    # run by filename below. Ranking on ``datetime`` would not help either: it is a
+    # refresh timestamp, identical across items to the microsecond.
     if dataset in FORECAST_CSV_COLLECTIONS and items:
-        items.sort(
-            key=lambda x: x.get("properties", {}).get("datetime", x.get("id", "")),
-            reverse=True,
-        )
-        items = items[:1]
+        items.sort(key=lambda x: x.get("id", ""))
 
     skip_data_type_filter = dataset in FORECAST_CSV_COLLECTIONS
     csv_hrefs: list[str] = []
@@ -632,6 +633,14 @@ def load(
                 if slice_ is not None and slice_ not in time_slice:
                     continue
             csv_hrefs.append(href)
+
+    # Narrow forecasts to the newest model run — the retained window holds ~40 runs
+    # of ~32 files each, and load() wants the current forecast, not all of them.
+    if dataset in FORECAST_CSV_COLLECTIONS and csv_hrefs:
+        runs = {run for href in csv_hrefs if (run := forecast_run_from_filename(href.split("?", 1)[0])) is not None}
+        if runs:
+            latest_run = max(runs)
+            csv_hrefs = [href for href in csv_hrefs if forecast_run_from_filename(href.split("?", 1)[0]) == latest_run]
 
     if not csv_hrefs:
         filters = f"station={station}, frequency={frequency}, time_slice={time_slice}"

--- a/src/foehn/client.py
+++ b/src/foehn/client.py
@@ -23,6 +23,7 @@ from foehn.collections import (
     COLLECTIONS,
     FORECAST_CSV_COLLECTIONS,
     STAC_API_BASE,
+    forecast_run_from_filename,
     time_slice_from_filename,
 )
 from foehn.convert import decode_meteoswiss_csv
@@ -216,14 +217,14 @@ def download_collection(
             logger.info("  Nothing changed — skipping")
             return DownloadResult()
 
-    # For forecast collections, only keep the latest item (newest forecast run)
+    # NB: a forecast item is one *day* (e.g. "20260722-ch") holding that day's ~24
+    # hourly runs × 32 parameters, not a single forecast. Selecting the latest item
+    # therefore did not select the latest run — and since the newest item is created
+    # at ~04:00 UTC and filled as the day's runs publish, it is routinely empty,
+    # which is what produced zero CSVs. Keep every item here and narrow to the
+    # newest run below, from the filenames.
     if collection_key in FORECAST_CSV_COLLECTIONS and items:
-        items.sort(
-            key=lambda x: x.get("properties", {}).get("datetime", x.get("id", "")),
-            reverse=True,
-        )
-        items = items[:1]
-        logger.info("  Using latest forecast: %s", items[0].get("id", "?"))
+        items.sort(key=lambda x: x.get("id", ""))
 
     # Collect matching CSV assets. ``all_csv_hrefs`` is the full pre-filter set
     # (every CSV in the listing, regardless of time slice) — the prune universe
@@ -244,6 +245,19 @@ def download_collection(
                 if slice_ is not None and slice_ not in data_types:
                     continue
             csv_assets.append((href, asset_info))
+
+    # One forecast run is ~32 files at ~30 MB each (~1 GB); the full retained
+    # window is ~40 runs (~40 GB). Keep only the newest complete-ish run.
+    if collection_key in FORECAST_CSV_COLLECTIONS and csv_assets:
+        runs = {run for href, _ in csv_assets if (run := forecast_run_from_filename(href.split("?", 1)[0])) is not None}
+        if runs:
+            latest_run = max(runs)
+            csv_assets = [
+                (href, info)
+                for href, info in csv_assets
+                if forecast_run_from_filename(href.split("?", 1)[0]) == latest_run
+            ]
+            logger.info("  Latest forecast run: %s (of %d available)", latest_run, len(runs))
 
     logger.info("  %d CSV files to process", len(csv_assets))
 

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -82,6 +82,8 @@ format — this is what each foehn reader relies on:
             ODIM reader extracts these to build the scaled, LV95-georeferenced grid.
 """
 
+import re
+
 STAC_API_BASE = "https://data.geo.admin.ch/api/stac/v1"
 
 # Maps our short key → STAC collection ID.
@@ -413,3 +415,21 @@ def time_slice_from_filename(filename: str) -> str | None:
     stem = filename.rsplit("/", 1)[-1].rsplit(".", 1)[0]
     last = stem.rsplit("_", 1)[-1]
     return last if last in TIME_SLICES else None
+
+
+# Forecast CSV assets are named ``vnut12.lssw.<YYYYMMDDHHMM>.<param>.csv``, where
+# the middle field is the model run time — i.e. when the forecast was issued. Note
+# this is NOT the "reference timestamp" of MeteoSwiss's docs, which is the ``Date``
+# column inside the file (the end of each forecast step's aggregation interval).
+_FORECAST_RUN_RE = re.compile(r"^vnut\d+\.lssw\.(\d{12})\..+\.csv$")
+
+
+def forecast_run_from_filename(filename: str) -> str | None:
+    """Return the run timestamp of a forecast CSV asset, or None if unrecognised.
+
+    e.g. ``vnut12.lssw.202607210600.dkl010h0.csv`` → ``"202607210600"``. The
+    zero-padded ``YYYYMMDDHHMM`` form sorts lexicographically, so callers can
+    pick the newest run by ``max()`` without parsing it into a datetime.
+    """
+    match = _FORECAST_RUN_RE.match(filename.rsplit("/", 1)[-1])
+    return match.group(1) if match else None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -223,6 +223,73 @@ def test_load_forecast_local_adds_reference_timestamp(mock_session, mock_meta, m
     assert df["reference_timestamp"][0].year == 2026
 
 
+def _forecast_item(item_id: str, runs: dict[str, list[str]]) -> dict:
+    """Build a forecast STAC item: one item = one day, holding several hourly runs."""
+    return {
+        "id": item_id,
+        # All items share a near-identical refresh timestamp upstream — it is not
+        # the forecast date, so item selection must not rank on it.
+        "properties": {"datetime": "2026-07-21T04:00:16.387170Z"},
+        "assets": {
+            f"{run}.{param}": {"href": f"https://data.geo.admin.ch/x/vnut12.lssw.{run}.{param}.csv"}
+            for run, params in runs.items()
+            for param in params
+        },
+    }
+
+
+@patch("foehn.api.get_collection_items")
+@patch("foehn.api.get_collection_metadata")
+@patch("foehn.api._retry_session")
+def test_load_forecast_local_skips_empty_newest_item(mock_session, mock_meta, mock_items):
+    """The newest day is created empty at ~04:00 UTC and filled as runs publish.
+
+    Selecting it as "latest" returned zero CSVs — the cause of issue #27.
+    """
+    mock_meta.return_value = {"assets": {}}
+    mock_items.return_value = [
+        _forecast_item("20260720-ch", {"202607200600": ["dkl010h0"]}),
+        _forecast_item("20260721-ch", {"202607210600": ["dkl010h0"]}),
+        _forecast_item("20260722-ch", {}),  # newest day, not yet populated
+    ]
+    session = MagicMock()
+    session.get = MagicMock(return_value=_mock_response(_FORECAST_LOCAL_CSV))
+    session.__enter__.return_value = session
+    mock_session.return_value = session
+
+    df = load("forecast_local")
+    assert len(df) > 0
+    # Newest *run* across the populated days, not the newest item.
+    assert "202607210600" in session.get.call_args[0][0]
+
+
+@patch("foehn.api.get_collection_items")
+@patch("foehn.api.get_collection_metadata")
+@patch("foehn.api._retry_session")
+def test_load_forecast_local_fetches_only_latest_run(mock_session, mock_meta, mock_items):
+    """One run is ~32 files at ~30 MB; the retained window is ~40 runs (~40 GB)."""
+    mock_meta.return_value = {"assets": {}}
+    mock_items.return_value = [
+        _forecast_item(
+            "20260721-ch",
+            {
+                "202607210400": ["dkl010h0", "fu3010h0"],
+                "202607210500": ["dkl010h0", "fu3010h0"],
+                "202607210600": ["dkl010h0", "fu3010h0"],
+            },
+        )
+    ]
+    session = MagicMock()
+    session.get = MagicMock(return_value=_mock_response(_FORECAST_LOCAL_CSV))
+    session.__enter__.return_value = session
+    mock_session.return_value = session
+
+    load("forecast_local")
+    fetched = [c[0][0] for c in session.get.call_args_list]
+    assert len(fetched) == 2
+    assert all("202607210600" in url for url in fetched)
+
+
 @patch("foehn.api.download_collection")
 @patch("foehn.api.download_metadata")
 def test_download_calls_underlying_functions(mock_meta, mock_dl, tmp_path):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -9,6 +9,7 @@ from foehn.collections import (
     GRIB2_COLLECTIONS,
     NETCDF_COLLECTIONS,
     PREAMBLE_CSV_COLLECTIONS,
+    forecast_run_from_filename,
     time_slice_from_filename,
 )
 
@@ -130,3 +131,25 @@ def test_spatial_climate_analysis_grids_are_netcdf():
     for key in ("radar_derived_grid", "climate_normals_grid"):
         assert COLLECTION_META[key]["format"] == "NetCDF"
         assert key in NETCDF_COLLECTIONS
+
+
+# --- forecast run timestamps ---
+
+
+def test_forecast_run_from_filename():
+    assert forecast_run_from_filename("vnut12.lssw.202607210600.dkl010h0.csv") == "202607210600"
+
+
+def test_forecast_run_from_filename_parses_full_url():
+    href = "https://data.geo.admin.ch/ch.meteoschweiz.ogd-local-forecasting/20260719-ch/vnut12.lssw.202607191200.fu3q10h1.csv"
+    assert forecast_run_from_filename(href) == "202607191200"
+
+
+def test_forecast_run_from_filename_rejects_non_forecast_names():
+    assert forecast_run_from_filename("ogd-smn_ber_d_recent.csv") is None
+    assert forecast_run_from_filename("ogd-local-forecasting_meta_point.csv") is None
+
+
+def test_forecast_runs_sort_lexicographically():
+    runs = ["202607210600", "202606300000", "202607192300"]
+    assert max(runs) == "202607210600"


### PR DESCRIPTION
Fixes #27.

## The bug

A `forecast_local` STAC item is **one day**, not one forecast. Each day holds that day's ~24 hourly runs × 32 parameters. We kept only the latest item:

```
20260719-ch  assets=384
20260720-ch  assets=754
20260721-ch  assets=217
20260722-ch  assets=0    <- selected as "latest"
```

The newest day is created around 04:00 UTC and filled as its runs publish, so it is routinely empty — hence zero CSVs and an empty result.

A second, latent problem: item selection sorted on `properties.datetime`, which is a *refresh* timestamp identical across all items to the microsecond (`...387170Z`, `...387330Z`, `...387584Z`), not the forecast date. It ordered items essentially by accident.

## The fix

Select the newest **run**, parsed from the asset filename (`vnut12.lssw.<YYYYMMDDHHMM>.<param>.csv`), rather than the newest item. That matches how MeteoSwiss actually publishes the data:

> The data is split by parameter. A file for a parameter contains all available points in one file.

So one run = 32 files, one per parameter, each covering all ~5,600 points. Applied in both `download_collection` and `load()`, via a new `forecast_run_from_filename()` helper.

Selection now goes 1355 assets -> 43 runs -> newest run -> **32 files**, with every filename parsing cleanly (no silent drops).

## Verified

- Real download path with the byte transfer stubbed: `0 CSV files to process` -> `32 CSV files to process`, single run `202607210600`.
- One real 30 MB CSV fetched and parsed end to end: 1,237,940 rows across 5,538 points, timestamps parsed correctly.
- 339 tests pass, including 6 new regression tests — one reproduces the empty-newest-item shape directly.

## Note on volume

One run is ~1 GB (32 files × ~30 MB). That is genuinely one full forecast, so it is the default here, but a `--parameter` filter would make this much more practical — most users want a few of the 32 parameters, not all. Worth a follow-up.
