### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "foehn"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python toolkit for Swiss weather data — download, query, and analyse MeteoSwiss Open Government Data"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.kayhendriksen/foehn",
   "title": "foehn",
   "description": "Access Swiss meteorological open data from MeteoSwiss, powered by foehn",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "websiteUrl": "https://github.com/kayhendriksen/foehn",
   "repository": {
     "url": "https://github.com/kayhendriksen/foehn",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "foehn",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/foehn/__init__.py
+++ b/src/foehn/__init__.py
@@ -1,6 +1,6 @@
 """foehn — Download MeteoSwiss Open Government Data and convert to Parquet."""
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 try:
     import polars as pl

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,28 @@
+"""Tests that the declared version is consistent across the repo."""
+
+import json
+import tomllib
+from pathlib import Path
+
+import foehn
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject_version() -> str:
+    with (ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
+
+
+def test_dunder_version_matches_pyproject():
+    """__version__ is not checked by the publish workflow, so it can drift silently."""
+    assert foehn.__version__ == _pyproject_version()
+
+
+def test_server_json_versions_match_pyproject():
+    """The publish workflow rewrites server.json from the tag; keep the committed
+    copy in sync so a local read never reports a stale version."""
+    server = json.loads((ROOT / "server.json").read_text())
+    expected = _pyproject_version()
+    assert server["version"] == expected
+    assert [p["version"] for p in server["packages"]] == [expected]


### PR DESCRIPTION
Unblocks the v0.3.3 release — `publish.yml` failed with:

```
Tag (0.3.3) does not match pyproject.toml version (0.3.2)
```

## Changes

Bumped `0.3.2` -> `0.3.3` in all three tracked places:

| File | Note |
|---|---|
| `pyproject.toml` | the one the publish workflow checks against the tag |
| `src/foehn/__init__.py` | `__version__`, **not** checked by CI — would have shipped stale |
| `server.json` | 2 occurrences (`.version`, `.packages[0].version`) |

`server.json` is rewritten from the tag at publish time, so that one is cosmetic — but keeping the committed copy in sync means reading the file locally doesn't report a stale version.

## Added a guard

`__version__` had no check tying it to `pyproject.toml`, which is why it drifted. `tests/test_version.py` now asserts both it and the `server.json` fields match. Verified it fails when the versions diverge, rather than passing vacuously.

341 tests pass.
