### PR TITLE
Harden CI pipeline: typecheck, zizmor, live-API canary, SBOM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,27 @@ updates:
       day: monday
       time: "09:00"
       timezone: Europe/Zurich
+    open-pull-requests-limit: 5
+    # Don't pull a release the moment it lands. A compromised release is usually
+    # yanked within days, so a short soak is cheap supply-chain insurance.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     groups:
-      python-dependencies:
+      # Split so a breaking major can't hold the safe patches hostage in one PR.
+      python-patch-minor:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+      python-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -19,7 +36,21 @@ updates:
       day: monday
       time: "09:30"
       timezone: Europe/Zurich
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
     groups:
-      github-actions:
+      github-actions-patch-minor:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+      github-actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,56 +8,142 @@ on:
 permissions:
   contents: read
 
+# Supersede in-flight runs for the same PR. Pushes to main are never cancelled —
+# each main commit should get a complete, attributable result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Single source of truth for the pinned dev toolchain. RUFF_VERSION must stay
+  # in step with .pre-commit-config.yaml so local hooks and CI agree — a drifting
+  # ruff turns green PRs red with no code change.
+  RUFF_VERSION: "0.16.4"
+  TY_VERSION: "0.0.74"
+  ZIZMOR_VERSION: "1.29.0"
+  PIP_AUDIT_VERSION: "2.9.0"
+  BANDIT_VERSION: "1.9.4"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: "3.12"
-      - run: pip install ruff
-      - run: ruff check src/ tests/
-      - run: ruff format --check src/ tests/
+          enable-cache: true
+      # scripts/ is linted too — ingest_delta.py builds Spark SQL by hand and is
+      # the highest-risk file in the repo.
+      - run: uvx ruff@${RUFF_VERSION} check src/ tests/ scripts/
+      - run: uvx ruff@${RUFF_VERSION} format --check src/ tests/ scripts/
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      # foehn ships py.typed, so downstream type checkers trust these annotations.
+      # Nothing verified them before this job existed.
+      - run: uv venv --python 3.12
+      - run: uv pip install -e ".[dev]" "ty==${TY_VERSION}"
+      - run: .venv/bin/ty check src/
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.python-version }}
-      - run: pip install -e ".[dev]"
-      - run: pytest --cov=foehn --cov-report=term-missing
+          enable-cache: true
+      - run: uv venv --python ${{ matrix.python-version }}
+      - run: uv pip install -e ".[dev]"
+      # Coverage floor lives in [tool.coverage.report] fail_under in pyproject.toml.
+      - run: .venv/bin/pytest --cov=foehn --cov-report=term-missing
 
-  security:
+  build:
+    name: build (packaging smoke test)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: "3.x"
-      - run: pip install pip-audit bandit
-      - name: Build audit requirements
-        run: |
-          python - <<'PY' > _audit_requirements.txt
-          import tomllib
-          from pathlib import Path
+          enable-cache: true
+      # publish.yml only builds at release time, from a tag-triggered job. Without
+      # this, a broken pyproject.toml or missing package data surfaces mid-release
+      # instead of in the PR that caused it.
+      - run: uv build
+      - run: uvx twine check dist/*
+      # Confirm the built wheel actually imports and exposes its entry point,
+      # rather than only that it is well-formed metadata.
+      - run: uv venv --python 3.12 /tmp/wheeltest
+      - run: VIRTUAL_ENV=/tmp/wheeltest uv pip install dist/*.whl
+      - run: /tmp/wheeltest/bin/foehn --help
+      - run: /tmp/wheeltest/bin/python -c "import foehn; print(foehn.__version__)"
 
-          project = tomllib.loads(Path("pyproject.toml").read_text())["project"]
-          requirements = list(project["dependencies"])
-          for extra in ("mcp",):
-              requirements.extend(project["optional-dependencies"].get(extra, []))
-          print("\n".join(requirements))
-          PY
-      - run: pip-audit -r _audit_requirements.txt --progress-spinner off
-      - run: bandit -r src/
+  security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      # Audit the *fully resolved* tree across every extra — including grids
+      # (netCDF4/h5py/eccodes/cfgrib/pyproj), which the previous hand-built
+      # requirements list left unaudited despite being C-library-backed.
+      - name: Resolve full dependency tree (all extras)
+        run: uv pip compile --quiet --all-extras pyproject.toml -o requirements-audit.txt
+      - name: Audit dependencies
+        run: uvx pip-audit@${PIP_AUDIT_VERSION} -r requirements-audit.txt --progress-spinner off
+      # scripts/ included — see the lint job.
+      - name: Static security scan
+        run: uvx bandit@${BANDIT_VERSION} -r src/ scripts/ -q
+
+  zizmor:
+    name: zizmor (workflow audit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Upload findings to the Security tab, alongside CodeQL and Scorecard.
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      # Static analysis for the workflows themselves: template injection, unpinned
+      # actions, credential persistence, over-broad permissions. Clean as of this
+      # commit — the point is to keep it that way as workflows change.
+      - name: Run zizmor
+        run: uvx zizmor@${ZIZMOR_VERSION} --format sarif .github/workflows/ > zizmor.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF
+        if: always() && hashFiles('zizmor.sarif') != ''
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -1,0 +1,78 @@
+name: Live API check
+
+# foehn is a thin client over the MeteoSwiss STAC/S3 API, so the failure mode
+# that matters most is upstream changing shape — not our own regressions. The
+# `live` marker is deselected by default (see addopts in pyproject.toml), which
+# meant these tests never ran anywhere. This runs them on a schedule and opens
+# an issue when MeteoSwiss drifts.
+on:
+  schedule:
+    - cron: "15 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - run: uv venv --python 3.12
+      - run: uv pip install -e ".[dev]"
+
+      - name: Run live tests
+        id: live
+        # -m live overrides the default `-m 'not live'` from addopts.
+        run: .venv/bin/pytest -m live -v --no-header
+
+      - name: Open or update tracking issue on failure
+        if: failure() && steps.live.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh label create live-check-failure \
+            --color B60205 \
+            --description "Scheduled live MeteoSwiss API check is failing" \
+            --force
+
+          # One rolling issue rather than a new one every week.
+          existing=$(gh issue list --state open --label live-check-failure \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body \
+              "Live API check failed again on $(date -u +%Y-%m-%d). Run: ${RUN_URL}"
+          else
+            gh issue create \
+              --title "Live MeteoSwiss API check is failing" \
+              --label live-check-failure \
+              --body "$(printf '%s\n' \
+                "The scheduled \`live\` test run failed, which usually means MeteoSwiss changed" \
+                "the STAC/S3 response shape rather than that foehn regressed." \
+                "" \
+                "Run: ${RUN_URL}" \
+                "" \
+                "Reproduce locally with:" \
+                "" \
+                '```bash' \
+                "pytest -m live -v" \
+                '```' \
+                "" \
+                "This issue is reused by later failures — close it once the check is green.")"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,15 @@ on:
 permissions:
   contents: read
 
+# A release should never be published twice concurrently; never cancel one either.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -17,6 +23,13 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+      # Used only for the SBOM scratch environment below — the published sdist
+      # and wheel are still built by the pinned `python3 -m build`.
+      # Caching is deliberately OFF here: this job produces the artifact that
+      # gets published, and a poisoned cache entry could reach PyPI.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: false
       # Pinned: this job builds the published artifact. Bump manually —
       # Dependabot doesn't track inline pip installs in workflows.
       - run: pip install build==1.5.0 twine==6.2.0
@@ -30,14 +43,53 @@ jobs:
           fi
       - run: python3 -m build
       - run: twine check dist/*
+      # CycloneDX SBOM of what actually ships, resolved by installing the built
+      # wheel rather than from the pyproject specs. Written outside dist/ — the
+      # publish job uploads all of dist/ to PyPI, which would reject a stray file.
+      - name: Generate SBOM
+        run: |
+          set -euo pipefail
+          mkdir -p sbom
+          # Scanned env holds the wheel and nothing else — uv venv omits pip, and
+          # the SBOM tool lives in a separate env so its own dependency tree does
+          # not leak into foehn's.
+          uv venv /tmp/sbomenv --python 3.12
+          VIRTUAL_ENV=/tmp/sbomenv uv pip install --quiet dist/*.whl
+          uvx --from cyclonedx-bom==7.3.1 cyclonedx-py environment /tmp/sbomenv \
+            --pyproject pyproject.toml \
+            --output-format JSON \
+            --output-file "sbom/foehn-${GITHUB_REF_NAME#v}-sbom.cdx.json"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: sbom/
+
+  attach-sbom:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # Only to add the SBOM as a release asset.
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+          path: sbom/
+      - name: Upload SBOM to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "${GITHUB_REF_NAME}" sbom/*.cdx.json --clobber
 
   publish:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: pypi
     permissions:
       actions: read
@@ -57,6 +109,7 @@ jobs:
   mcp-registry:
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write
       contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,31 @@
+# Keep the ruff rev in step with RUFF_VERSION in .github/workflows/ci.yml —
+# a mismatch means hooks and CI disagree about what "clean" means.
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.7
+    rev: v0.16.4
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      # Catches a malformed workflow before it is ever pushed.
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      # The grids tests carry NetCDF/GRIB2 fixtures; keep an accidental
+      # multi-megabyte capture out of git history.
+      - id: check-added-large-files
+        args: [--maxkb=2048]
+
+  # Workflow static analysis, same version CI runs.
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+      - id: zizmor

--- a/docs/grids.md
+++ b/docs/grids.md
@@ -260,6 +260,6 @@ foehn to-zarr surface_derived_grid --match rhiresd --out out/rain.zarr
 The MCP server exposes the inspect path as the `describe_grid` tool (any gridded
 format): it returns a grid's dimensions, coordinates, and variables without
 streaming array values into the LLM context (it does cache the source file — the
-same download-then-lazy caveat, hence it's annotated `readOnlyHint=False`).
+same download-then-lazy caveat, hence it's annotated `read_only_hint=False`).
 Writing Zarr stores (`to_zarr`) is intentionally not exposed over MCP — conversion/
 write tools aren't part of the MCP surface. See the [MCP server docs](mcp-server.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,12 @@ line-length = 120
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "UP", "B", "C4", "SIM", "RUF", "A", "PIE", "PERF", "T20"]
+select = [
+    "E", "F", "I", "W", "UP", "B", "C4", "SIM", "RUF", "A", "PIE", "PERF", "T20",
+    "S",    # flake8-bandit — inline security lint (bandit still runs in CI for the deeper pass)
+    "DTZ",  # naive datetimes — a weather library should never build one by accident
+    "PTH",  # pathlib over os.path
+]
 ignore = [
     "E731",   # lambda assignment — sometimes fine
     "SIM108", # ternary operator — can hurt readability
@@ -101,6 +106,19 @@ ignore = [
 "src/foehn/convert.py" = ["T201"]
 "src/foehn/mcp_server.py" = ["T201"]
 "scripts/*" = ["T201", "PERF203"]
+# Tests assert freely, build naive datetimes as fixture values, and open() by
+# path is clearer than Path.open() when the path is a plain string literal.
+"tests/*" = ["S101", "DTZ001", "PTH123"]
+
+[tool.coverage.run]
+source = ["foehn"]
+branch = true
+
+[tool.coverage.report]
+# Branch coverage currently sits at ~89%. Kept a couple of points below so
+# ordinary churn doesn't go red, but a real regression does.
+fail_under = 87
+show_missing = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/ingest_delta.py
+++ b/scripts/ingest_delta.py
@@ -316,12 +316,18 @@ def _ingest_radar(
         view = f"_{key}_new"
         new_df.createOrReplaceTempView(view)
         # WHEN MATCHED: pick up reanalysis overwrites (local mtime bumped, row should too).
-        spark.sql(
-            f"MERGE INTO {table} t USING {view} s ON t.path = s.path "
+        # The interpolated names are not user-controlled SQL: `table` is built from
+        # `cat`/`sch`, which both passed _validate_identifier (alphanumerics, underscore,
+        # hyphen; backtick-quoted), and from `key`, which the caller constrains to
+        # RADAR_COLLECTIONS literals. `view` derives from that same literal. Hence the
+        # suppression on the MERGE below.
+        merge_sql = (
+            f"MERGE INTO {table} t USING {view} s ON t.path = s.path "  # nosec B608
             "WHEN MATCHED AND s.modification_time > t.modification_time THEN UPDATE SET "
             "  modification_time = s.modification_time, size_bytes = s.size_bytes "
             "WHEN NOT MATCHED THEN INSERT *"
         )
+        spark.sql(merge_sql)
 
         count = new_df.count()
         print(f"  OK  {key:25s} → {table} ({count} files indexed)", flush=True)

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -586,7 +586,7 @@ def load(
     collection_id = COLLECTIONS[dataset]
 
     # 1. Fetch metadata types for schema inference.
-    metadata_types: dict[str, pl.DataType] = {}
+    metadata_types: dict[str, type[pl.DataType]] = {}
     coll = get_collection_metadata(collection_id)
     for asset_info in coll.get("assets", {}).values():
         href = asset_info.get("href", "")

--- a/src/foehn/cli.py
+++ b/src/foehn/cli.py
@@ -326,6 +326,14 @@ def cmd_load(args: argparse.Namespace) -> None:
     print(f"\n[{df.shape[0]} rows x {df.shape[1]} columns]")
 
 
+class _FoehnCliHandler(logging.StreamHandler):
+    """Marker subclass so repeat invocations can find and reuse *our* handler.
+
+    A plain ``StreamHandler`` would be indistinguishable from one an embedding
+    application attached to the ``foehn`` logger itself.
+    """
+
+
 def _configure_logging() -> None:
     """Route the foehn library's logger to stdout for CLI use.
 
@@ -340,12 +348,11 @@ def _configure_logging() -> None:
     """
     foehn_logger = logging.getLogger("foehn")
     handler = next(
-        (h for h in foehn_logger.handlers if getattr(h, "_foehn_cli_handler", False)),
+        (h for h in foehn_logger.handlers if isinstance(h, _FoehnCliHandler)),
         None,
     )
     if handler is None:
-        handler = logging.StreamHandler(sys.stdout)
-        handler._foehn_cli_handler = True  # type: ignore[attr-defined]
+        handler = _FoehnCliHandler(sys.stdout)
         foehn_logger.addHandler(handler)
     else:
         # Repoint at the current stdout without setStream(), which would first

--- a/src/foehn/client.py
+++ b/src/foehn/client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import threading
 import zipfile
 from collections.abc import Callable
@@ -101,11 +100,11 @@ def _thread_local_session() -> Callable[[], requests.Session]:
 
 
 def _atomic_write_text(path: Path, text: str) -> None:
-    """Write text via a sibling temp file + os.replace so readers never see a torn write."""
+    """Write text via a sibling temp file + Path.replace so readers never see a torn write."""
     tmp = path.with_name(path.name + ".tmp")
     try:
         tmp.write_text(text, encoding="utf-8")
-        os.replace(tmp, path)
+        tmp.replace(path)
     except BaseException:
         tmp.unlink(missing_ok=True)
         raise
@@ -401,7 +400,7 @@ def _needs_redownload(filepath: Path, remote_updated: str) -> bool:
 def _download_binary(session: requests.Session, href: str, filepath: Path, timeout: int = 120) -> str:
     """Stream a binary asset to disk atomically. Returns the filename.
 
-    Streams into a sibling ``.part`` file and only ``os.replace``s it onto the
+    Streams into a sibling ``.part`` file and only ``Path.replace``s it onto the
     final path once the body is fully written. A timeout or connection drop
     mid-stream therefore leaves no file at ``filepath`` — so the next run's
     existence/mtime check won't mistake a truncated download for a complete one.
@@ -414,7 +413,7 @@ def _download_binary(session: requests.Session, href: str, filepath: Path, timeo
             with tmp.open("wb") as f:
                 for chunk in resp.iter_content(chunk_size=65536):
                     f.write(chunk)
-        os.replace(tmp, filepath)
+        tmp.replace(filepath)
     except BaseException:
         tmp.unlink(missing_ok=True)
         raise

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -28,13 +28,13 @@ def decode_meteoswiss_csv(content: bytes) -> str:
         return content.decode("windows-1252", errors="replace")
 
 
-_DTYPE_MAP: dict[str, pl.DataType] = {
+_DTYPE_MAP: dict[str, type[pl.DataType]] = {
     "float": pl.Float64,
     "integer": pl.Int64,
 }
 
 
-def _parse_metadata_types(content: bytes | str) -> dict[str, pl.DataType]:
+def _parse_metadata_types(content: bytes | str) -> dict[str, type[pl.DataType]]:
     """Build a parameter→Polars dtype mapping from metadata CSV content.
 
     Works with both raw bytes (in-memory) and string content.
@@ -50,7 +50,7 @@ def _parse_metadata_types(content: bytes | str) -> dict[str, pl.DataType]:
     if "parameter_shortname" not in meta.columns or "parameter_datatype" not in meta.columns:
         return {}
 
-    type_map: dict[str, pl.DataType] = {}
+    type_map: dict[str, type[pl.DataType]] = {}
     for row in meta.select("parameter_shortname", "parameter_datatype").iter_rows():
         shortname, datatype = row
         if shortname and datatype:
@@ -60,7 +60,7 @@ def _parse_metadata_types(content: bytes | str) -> dict[str, pl.DataType]:
     return type_map
 
 
-def _load_metadata_types(csv_dir: Path) -> dict[str, pl.DataType]:
+def _load_metadata_types(csv_dir: Path) -> dict[str, type[pl.DataType]]:
     """Build a parameter→Polars dtype mapping from a *_meta_parameters.csv file.
 
     Returns an empty dict if no metadata file is found or if the expected
@@ -79,8 +79,8 @@ def _load_metadata_types(csv_dir: Path) -> dict[str, pl.DataType]:
 
 def parse_csv_bytes(
     content: bytes,
-    metadata_types: dict[str, pl.DataType] | None = None,
-    _fallback_overrides: dict[str, pl.DataType] | None = None,
+    metadata_types: dict[str, type[pl.DataType]] | None = None,
+    _fallback_overrides: dict[str, type[pl.DataType]] | None = None,
 ) -> pl.DataFrame:
     """Parse CSV bytes into a Polars DataFrame, applying metadata type overrides.
 
@@ -96,15 +96,15 @@ def parse_csv_bytes(
     buf = io.BytesIO(content)
 
     # Build per-file overrides by matching CSV columns to metadata types.
-    overrides: dict[str, pl.DataType] = {}
+    overrides: dict[str, type[pl.DataType]] = {}
     if metadata_types:
         try:
             header = pl.read_csv(io.BytesIO(content), separator=";", n_rows=0, infer_schema_length=0).columns
             for col in header:
                 if col in metadata_types:
                     overrides[col] = metadata_types[col]
-        except Exception:  # nosec B110
-            pass
+        except Exception as exc:
+            logger.debug("Could not read CSV header for schema overrides (%s) — inferring types", exc)
 
     try:
         return pl.read_csv(
@@ -228,7 +228,7 @@ def convert_to_parquet(collection_key: str, bronze_dir: Path, parquet_dir: Path)
         # name out of the polars error, force it to Float64, and retry.  RSS
         # stays bounded — the alternative of materialising every CSV blew up
         # the driver on historical groups.
-        overrides: dict[str, pl.DataType] = dict(metadata_types or {})
+        overrides: dict[str, type[pl.DataType]] = dict(metadata_types or {})
         recovered: list[str] = []
         try:
             while True:

--- a/src/foehn/mcp_server.py
+++ b/src/foehn/mcp_server.py
@@ -4,12 +4,13 @@ Provides mostly read-only access to Swiss meteorological open data through a set
 of query tools, a reference guide resource, and a prompt template. The tabular
 tools fetch live from the MeteoSwiss STAC API without touching local state; the
 one exception is ``describe_grid``, which downloads the source grid file (NetCDF,
-GRIB2, or radar) into the local bronze cache (annotated ``readOnlyHint=False``).
+GRIB2, or radar) into the local bronze cache (annotated ``read_only_hint=False``).
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 import polars as pl
 from mcp.server.mcpserver import MCPServer
@@ -35,20 +36,20 @@ _VALID_CATEGORIES = {"A", "C", "D", "E"}
 # The tabular query tools are read-only against the MeteoSwiss API (describe_grid
 # is the exception — it caches to disk, see _GRID_INSPECT below).
 _READ_ONLY = ToolAnnotations(
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=True,
 )
 
 # describe_grid inspects a gridded collection (NetCDF, GRIB2, or radar). It is
 # idempotent and never destructive, but it is not read-only: opening a grid
 # downloads the source file in full to the local bronze cache (download-then-lazy).
 _GRID_INSPECT = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
+    read_only_hint=False,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=True,
 )
 
 # Gridded collections describe_grid can inspect: every NetCDF, GRIB2, and HDF5
@@ -700,6 +701,6 @@ Mention that results are powered by foehn with data from MeteoSwiss."""
 # ── Entry point ──────────────────────────────────────────────────────────────
 
 
-def run(transport: str = "stdio") -> None:
+def run(transport: Literal["stdio", "sse", "streamable-http"] = "stdio") -> None:
     """Start the MCP server."""
     mcp.run(transport=transport)


### PR DESCRIPTION
Review of the GitHub Actions pipeline, plus the fixes. The baseline was already strong — SHA-pinned actions, `persist-credentials: false`, least-privilege permissions, OIDC trusted publishing with PEP 740 attestations, CodeQL, Scorecard, and a ruleset requiring all matrix legs. `zizmor` reported **zero findings** on the workflows as they stood. This is refinement on top of that.

## Security

- **`pip-audit` now audits the fully resolved tree across every extra.** It previously synthesised a requirements file from `dependencies` + the `mcp` extra only, leaving `grids` (netCDF4, h5py, eccodes, cfgrib, pyproj) and `databricks` unaudited — all C-library-backed, all installed by real users. Now `uv pip compile --all-extras` resolves the complete transitive tree (76 packages) and audits that. Currently clean.
- **`scripts/` is now linted and bandit-scanned.** `scripts/ingest_delta.py` is 355 lines of hand-built Spark SQL — the highest injection surface in the repo — and CI never looked at it, despite `pyproject.toml` already declaring `per-file-ignores` for `scripts/*`.
- **`zizmor` job added** with SARIF upload to the Security tab. It immediately caught two real issues in this very PR: uv caching enabled in the release-build job (a cache-poisoning path to PyPI) and an insufficient Dependabot cooldown. Both fixed here.
- **CycloneDX SBOM** attached to each release, generated from the built wheel in an isolated environment so tooling doesn't leak into it. `contents: write` is scoped to its own small job.
- **Dependabot cooldown** (7 days) so a compromised release gets a soak period before we pull it.

## Correctness

- **New `typecheck` job (`ty`).** foehn ships `py.typed`, so downstream type checkers trust these annotations, but nothing verified them. Found 9 diagnostics; all fixed (see below).
- **New `build` job** — packaging smoke test that builds, `twine check`s, installs the wheel into a clean env, and runs the entry point. Previously a broken `pyproject.toml` would only surface mid-release.
- **Coverage floor** at 87% via `[tool.coverage.report] fail_under`, with branch coverage enabled (currently 89.04%).
- **`live.yml`** — the `live` marker was deselected by `addopts` and ran nowhere, so the one test that catches MeteoSwiss changing their STAC/S3 shape was dead weight. Now runs weekly, opening (and reusing) a tracking issue on failure.
- **Pinned toolchain** in one `env` block. `ruff` was unpinned in CI (0.16.4), pinned at v0.15.7 in pre-commit, and `>=0.9` in the dev extra — three sources of truth, and a ruff release could turn a green PR red with no code change.
- **`concurrency` groups and `timeout-minutes`** on every job. Default timeout was 360 minutes.

## Code changes required by the above

| Fix | Why |
|---|---|
| `os.replace` → `Path.replace` in `client.py` | ruff `PTH105`; `os` import now unused |
| Silent `except/pass` in `convert.py` now logs at debug | ruff `S110`; silent failures were undiagnosable |
| `dict[str, pl.DataType]` → `dict[str, type[pl.DataType]]` | These hold dtype *classes* (`pl.Float64`), not instances — the annotation was simply wrong |
| `_FoehnCliHandler` marker subclass | Replaces attribute-stashing on a `StreamHandler` plus a `getattr` duck-type check |
| `run(transport: Literal[...])` | Was `str`, which matched no `MCPServer.run` overload |
| `ToolAnnotations` kwargs → snake_case | MCP 2.0 renamed these; camelCase survived only via the `to_camel` alias. **Wire format is unchanged** — verified both forms serialise identically |
| Justified `# nosec B608` on the radar MERGE | Bandit flags it, but `cat`/`sch` pass `_validate_identifier` and `key` is constrained to `RADAR_COLLECTIONS` literals |

## Verification

All rehearsed locally against a clean 3.12 environment before pushing:

- `ruff check` / `ruff format --check` over `src/ tests/ scripts/` — clean
- `ty check src/` — clean (was 9 diagnostics)
- 344 tests pass, 89.04% branch coverage
- `pip-audit` over all 76 resolved packages — no known vulnerabilities
- `bandit -r src/ scripts/` — clean
- `zizmor .github/` — clean
- `pre-commit run --all-files` — all 11 hooks pass
- Wheel builds, `twine check` passes, installs clean, `foehn --help` works
- SBOM generates with exactly foehn's 7-package runtime closure
- `pytest -m live` passes against the real MeteoSwiss API

## Follow-up needed after merge

The ruleset's required status checks still list only `lint`, `security`, `test (3.x)`, and `Analyze Python`. The new `typecheck`, `build`, and `zizmor` jobs need adding — I can do that once they've reported once on this PR.