### PR TITLE
Fix dependabot config: semver cooldown keys unsupported for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,11 +37,10 @@ updates:
       time: "09:30"
       timezone: Europe/Zurich
     open-pull-requests-limit: 5
+    # Only default-days here: Dependabot does not treat Action tags as semver,
+    # so the semver-*-days keys are rejected for this ecosystem.
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
     groups:
       github-actions-patch-minor:
         patterns:


### PR DESCRIPTION
The `cooldown` block added in #36 broke Dependabot config parsing. GitHub's exact error:

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

Dependabot doesn't classify Action tags as semver for cooldown purposes, so only `default-days` is accepted for that ecosystem. The `pip` block keeps the full set — it validated fine.

Note this was invisible to the checks I ran: the file is valid against the SchemaStore JSON schema (0 errors), and zizmor's `dependabot-cooldown` audit only checks that `default-days` is at least 7. The per-ecosystem restriction is enforced server-side by Dependabot only.

The `groups` split is unaffected — GitHub's error named only the three cooldown keys, so `update-types: [minor, patch]` / `[major]` grouping is accepted for both ecosystems.

Verified after the fix: schema-valid, zizmor clean, `default-days: 7` retained so the cooldown still applies to Actions updates.