### PR TITLE
Fix time_slice being ignored for decade-split historical files

### DIFF
--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -404,6 +404,13 @@ CLIMATE_NORMALS_ZIP_URL = "https://data.geo.admin.ch/ch.meteoschweiz.klima/normw
 TIME_SLICES = frozenset({"historical", "recent", "now"})
 
 
+# MeteoSwiss chunks the high-frequency historical series by decade, so the slice
+# is not always the trailing segment: ``ogd-smn_ber_t_historical_2000-2009.csv``.
+# Only a bare decade range is accepted as that trailing segment, which keeps the
+# "match the end, not anywhere" guard below intact.
+_DECADE_RANGE_RE = re.compile(r"^\d{4}-\d{4}$")
+
+
 def time_slice_from_filename(filename: str) -> str | None:
     """Return the time slice of a standard CSV asset, or None if it has none.
 
@@ -411,10 +418,21 @@ def time_slice_from_filename(filename: str) -> str | None:
     (e.g. ``ogd-smn_ber_d_recent.csv`` → ``"recent"``) rather than matching the
     token anywhere in the path, so a coincidental substring (notably the bare
     ``"now"``) elsewhere in the URL can't be misread as a time slice.
+
+    The ``t`` and ``h`` historical series are split per decade, in which case the
+    slice sits one segment further back (``..._historical_2000-2009.csv``). Those
+    are recognised too — without it the file parses as "no slice at all" and gets
+    treated as unsliced data that every query must include, so ``time_slice`` is
+    silently ignored and the full history ships on every call.
     """
     stem = filename.rsplit("/", 1)[-1].rsplit(".", 1)[0]
-    last = stem.rsplit("_", 1)[-1]
-    return last if last in TIME_SLICES else None
+    parts = stem.rsplit("_", 2)
+    last = parts[-1]
+    if last in TIME_SLICES:
+        return last
+    if len(parts) >= 2 and _DECADE_RANGE_RE.match(last) and parts[-2] in TIME_SLICES:
+        return parts[-2]
+    return None
 
 
 # Forecast CSV assets are named ``vnut12.lssw.<YYYYMMDDHHMM>.<param>.csv``, where

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -22,6 +22,26 @@ def test_time_slice_from_filename_detects_trailing_segment():
     assert time_slice_from_filename("https://data.geo.admin.ch/x/ogd-smn_ber_d_recent.csv") == "recent"
 
 
+def test_time_slice_from_filename_detects_decade_split_historical():
+    # MeteoSwiss splits the t/h historical series per decade. Parsing these as
+    # "no slice" makes every query pull the full history (see #39).
+    assert time_slice_from_filename("ogd-smn_ber_t_historical_2000-2009.csv") == "historical"
+    assert time_slice_from_filename("ogd-smn_ber_h_historical_1980-1989.csv") == "historical"
+    assert time_slice_from_filename("ogd-smn-tower_ban_h_historical_2020-2029.csv") == "historical"
+    assert time_slice_from_filename("https://data.geo.admin.ch/x/ogd-smn_ber_t_historical_2010-2019.csv") == (
+        "historical"
+    )
+
+
+def test_time_slice_from_filename_only_accepts_a_bare_decade_range():
+    # The one-segment-back lookup must not become a general "search anywhere".
+    assert time_slice_from_filename("ogd-smn_ber_t_historical_2000.csv") is None
+    assert time_slice_from_filename("ogd-smn_ber_t_historical_2000-2009-extra.csv") is None
+    assert time_slice_from_filename("ogd-smn_ber_t_notaslice_2000-2009.csv") is None
+    # A decade range with no slice in front of it is still unsliced data.
+    assert time_slice_from_filename("ogd-smn_ber_t_2000-2009.csv") is None
+
+
 def test_time_slice_from_filename_returns_none_when_absent():
     assert time_slice_from_filename("ogd-smn_ber_d.csv") is None
     # 'now' as a coincidental substring elsewhere must not be misread as a slice.


### PR DESCRIPTION
`time_slice` was silently ignored for 10-minute (`t`) and hourly (`h`) data. `load("smn", station="BER", time_slice="now")` returned **1,152,843 rows spanning 2004–2026** instead of the ~123 rows covering one day.

## Cause

MeteoSwiss splits the high-frequency historical series into decade chunks:

```
ogd-smn_ber_t_historical_2000-2009.csv
ogd-smn_ber_t_historical_2010-2019.csv
ogd-smn_ber_t_historical_2020-2029.csv
```

`time_slice_from_filename` read only the trailing `_`-separated segment, saw `"2000-2009"`, and returned `None`. Both call sites — `api.py:632` and `client.py:243` — use `if slice_ is not None and slice_ not in time_slice: continue`, so `None` means "unsliced data, always include" (correct for `_m`, `_y`, phenology). The decade files rode in on that exemption.

## Verification

Three independent checks, all against the live API.

**1. What the source files actually contain**, read directly, bypassing `load()`:

| file | rows | range |
|---|---|---|
| `..._t_now.csv` | 123 | 24.08.2026 00:00 → 20:20 |
| `..._t_recent.csv` | 33,840 | 01.01.2026 → 31.07.2026 |
| `..._t_historical_2000-2009.csv` | 311,184 | 01.01.2005 → 31.12.2009 |

Upstream scoping is correct — foehn was pulling extra files.

**2. Intercepted every URL `load()` requested** for `time_slice="now"` — 4 files: the three decade files plus `_now.csv`. Row total 1,152,843 reconciles exactly.

**3. Post-fix, live:**

| `time_slice` | files | rows | range |
|---|---|---|---|
| `now` | 1 | 123 | 2026-08-24 00:00 → 20:20 |
| `recent` | 1 | 33,840 | 2026-01-01 → 2026-08-23 |
| `historical` | 3 | 1,152,720 | 2004-02-01 → 2025-12-31 |

Every figure matches check 1 exactly.

## Impact

For one station at 10-min resolution, `time_slice="now"` transferred **152.1 MB to deliver 16.8 KB** — ~8,800× overhead. Affects `smn` (157 stations), `smn_precip` (141), `smn_tower` (3) at `t` and `h`. Daily has no decade split; `m`/`y` are genuinely unsliced. The docstring at `api.py:494` advising `time_slice="now"` "to reduce wire volume" now actually works.

Fixing the shared parser corrects both `load()` and `download()`.

## The fix

Accept the slice one segment back, but *only* when the trailing segment is a bare decade range (`^\d{4}-\d{4}$`). That keeps the existing "match the end, not anywhere" guard — `ogd-snow_ber_d.csv` must not read as `now`, and it still doesn't.

Four new tests cover the decade forms and the near-misses that must stay `None`: `_historical_2000` (not a range), `_historical_2000-2009-extra` (not bare), `_notaslice_2000-2009` (no slice in front), `_2000-2009` (range alone).

## Behavioural change

Callers using `time_slice="recent"` or `"now"` on `t`/`h` data currently receive the full history and will now get only the slice they asked for. That is the documented contract being restored rather than changed, but it does alter results in the field — worth a minor bump rather than a patch.

Verified: 346 tests pass, 89.09% branch coverage, live test passes, ruff and ty clean.