### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "foehn"
-version = "0.3.4"
+version = "0.4.0"
 description = "Python toolkit for Swiss weather data — download, query, and analyse MeteoSwiss Open Government Data"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.kayhendriksen/foehn",
   "title": "foehn",
   "description": "Access Swiss meteorological open data from MeteoSwiss, powered by foehn",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "websiteUrl": "https://github.com/kayhendriksen/foehn",
   "repository": {
     "url": "https://github.com/kayhendriksen/foehn",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "foehn",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/foehn/__init__.py
+++ b/src/foehn/__init__.py
@@ -1,6 +1,6 @@
 """foehn — Download MeteoSwiss Open Government Data and convert to Parquet."""
 
-__version__ = "0.3.4"
+__version__ = "0.4.0"
 
 try:
     import polars as pl


### PR DESCRIPTION
Version bump for the 0.4.0 release. Minor rather than patch: the `mcp` floor moves to 2.0, and `time_slice` now actually filters on `t`/`h` data.

Bumped in all four places: `pyproject.toml`, `src/foehn/__init__.py`, and both fields in `server.json`.

Verified: publish.yml's tag-match gate passes for `v0.4.0`, `foehn.__version__` agrees, 346 tests pass, sdist and wheel build and pass `twine check`.