### PR TITLE
Pin twine 7.0.0 in publish and match it in CI's build smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ env:
   TY_VERSION: "0.0.74"
   ZIZMOR_VERSION: "1.29.0"
   PIP_AUDIT_VERSION: "2.9.0"
+  # Must match the pins in publish.yml — the build job below is that job's smoke
+  # test, and only catches its failures if it runs the same toolchain.
+  BUILD_VERSION: "1.6.0"
+  TWINE_VERSION: "7.0.0"
   BANDIT_VERSION: "1.9.4"
 
 jobs:
@@ -89,8 +93,8 @@ jobs:
       # publish.yml only builds at release time, from a tag-triggered job. Without
       # this, a broken pyproject.toml or missing package data surfaces mid-release
       # instead of in the PR that caused it.
-      - run: uv build
-      - run: uvx twine check dist/*
+      - run: uvx --from build==${BUILD_VERSION} pyproject-build
+      - run: uvx twine@${TWINE_VERSION} check dist/*
       # Confirm the built wheel actually imports and exposes its entry point,
       # rather than only that it is well-formed metadata.
       - run: uv venv --python 3.12 /tmp/wheeltest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,10 @@ jobs:
           enable-cache: false
       # Pinned: this job builds the published artifact. Bump manually —
       # Dependabot doesn't track inline pip installs in workflows.
-      - run: pip install build==1.5.0 twine==6.2.0
+      # Keep in step with BUILD_VERSION/TWINE_VERSION in ci.yml, whose build job
+      # is the smoke test for this one. twine < 7 rejects Metadata-Version 2.5,
+      # which hatchling now emits.
+      - run: pip install build==1.6.0 twine==7.0.0
       - name: Verify tag matches pyproject.toml version
         run: |
           TAG="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
The v0.4.0 release failed in `publish.yml`'s build job:

```
Checking dist/foehn-0.4.0-py3-none-any.whl: ERROR
  InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Nothing was published — `build` failed, so `attach-sbom`, `publish`, and `mcp-registry` all skipped and `foehn 0.4.0` is not on PyPI. The v0.4.0 tag and release exist with no assets.

## Cause

`hatchling` is floored, not pinned (`requires = ["hatchling >= 1.26"]`), so it resolved to a version emitting `Metadata-Version: 2.5`. `twine==6.2.0` bundles a `packaging` that only knows up to 2.4, so it rejects its own valid artifact.

Confirmed the artifact is fine and the tool is at fault:

- PyPI already hosts 2.5 wheels — `hatchling 1.32.0`, `hatch 1.18.0`, `httpx 1.0.dev5`
- All four previously published foehn wheels are 2.4, so this is new drift
- Same wheel: `twine 6.2.0` → ERROR, `twine 7.0.0` → PASSED

## Why CI didn't catch it

This is the real defect. The `build` job added in #36 was meant to be the smoke test for `publish.yml`, but it ran a *different toolchain*: `uv build` + `uvx twine` (unpinned, latest) against publish's `python -m build` + `twine==6.2.0`. A smoke test on different versions than the thing it guards can't catch version drift — and didn't.

Both now run `build==1.6.0` and `twine==7.0.0`, with the versions in ci.yml's `env` block and a comment in each file pointing at the other.

## Verified

- Pinned path builds and passes `twine check`
- `twine 6.2.0` still rejects the same artifact, so the CI job would now reproduce the failure rather than mask it
- zizmor clean

## Follow-up not taken

`hatchling >= 1.26` stays a floor rather than a pin. Pinning the build backend would make builds reproducible but is unusual practice; with CI now exercising the real toolchain, drift surfaces in a PR instead of a release. Happy to pin it if you'd rather.