### PR TITLE
Prepare for Python 3.15: pin read encodings, add non-blocking preview CI leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,28 @@ jobs:
       # Coverage floor lives in [tool.coverage.report] fail_under in pyproject.toml.
       - run: .venv/bin/pytest --cov=foehn --cov-report=term-missing
 
+  test-prerelease:
+    # Python's 3.15 call-to-action asks maintainers to test against the preview.
+    # Non-blocking on purpose: this tracks upstream readiness, and a red preview
+    # leg must never gate a PR.
+    name: test (3.15 preview, non-blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - run: uv venv --python 3.15
+      # Core + mcp only. The grids stack has no 3.15 wheels yet (pandas, pyproj,
+      # netCDF4, h5py, pyarrow), so installing [dev] here would fail on packaging
+      # rather than on anything foehn controls.
+      - run: uv pip install -e ".[mcp]" "pytest>=8"
+      - run: .venv/bin/pytest --ignore=tests/test_grids.py -p no:cov
+
   build:
     name: build (packaging smoke test)
     runs-on: ubuntu-latest

--- a/src/foehn/client.py
+++ b/src/foehn/client.py
@@ -114,7 +114,7 @@ def load_etags(data_dir: Path) -> dict:
     path = data_dir / "_etags.json"
     if path.exists():
         try:
-            return json.loads(path.read_text())
+            return json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Could not read %s (%s) — treating as empty", path, exc)
     return {}
@@ -131,7 +131,7 @@ def load_last_run(data_dir: Path) -> str | None:
     path = data_dir / "_last_run.json"
     if path.exists():
         try:
-            data = json.loads(path.read_text())
+            data = json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Could not read %s (%s) — treating as no previous run", path, exc)
             return None


### PR DESCRIPTION
Response to Python's 3.15 call-to-action. Tested against **3.15.0b2**.

## Status: foehn does not yet work on 3.15, and the blocker is upstream

`Series.unique()` returns `None` on 3.15 with polars 1.44.1. Same polars version, different Python:

```
Python 3.15.0b2 / polars 1.44.1     Python 3.12.2 / polars 1.44.1
  Series.unique() -> None             Series.unique() -> shape: (2,) [...]
```

That single bug accounts for all 21 test failures on 3.15. Controlled for by running the identical dependency set (no pyarrow) on 3.12: **269 passed**. Nothing here is foehn's to fix — worth reporting to polars.

## PEP 686 (UTF-8 default encoding) — fixed

3.15 makes UTF-8 the default encoding, which silently changes any text I/O that omits `encoding=`. foehn had two:

```python
# client.py:117, :134
json.loads(path.read_text())        # locale encoding
```

Both read files that `_atomic_write_text` writes with `encoding="utf-8"` — written UTF-8, read as locale. That is a latent bug *today* on a non-UTF-8 Windows locale, and 3.15 would have changed the behaviour without warning. Now explicit.

Audited the rest: every other `.decode()`/`.encode()` in `src/` already names its codec, and `bytes.decode()` defaults to UTF-8 regardless of locale, so the windows-1252 CSV path is unaffected.

## Non-blocking preview CI leg

New `test (3.15 preview, non-blocking)` job with `continue-on-error: true`, so it tracks upstream readiness without ever gating a PR. It installs core + mcp only — the grids stack has no 3.15 wheels yet (pandas, pyproj, netCDF4, h5py, pyarrow), so a full `[dev]` install fails on packaging rather than on anything foehn controls.

## Deliberately NOT done

**No `Programming Language :: Python :: 3.15` classifier.** That claims support, and with polars broken foehn does not work on 3.15. Add it once the preview leg goes green.

## Wheels

Nothing to do — foehn is a pure-Python `py3-none-any` wheel, so it already installs on 3.15. The call-to-action's wheel-building request applies to projects shipping compiled extensions.

## Verified

346 tests pass on 3.12, ruff and ty clean, zizmor clean.