### PR TITLE
Name the dataset kind, collapse the routing ladders

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -35,7 +35,7 @@ Station-level time series in CSV, split into time slices (`historical`, `recent`
 | `climate_normals_*` | C7 | **Spatial normals (legacy)** -- gridded 30-year reference maps for precipitation, sunshine, and temperature (both reference periods). | NetCDF / GeoTIFF (opt-in) |
 | `climate_scenarios` | C8 | **CH2025 local scenarios** -- daily station-level climate projections, one column per climate model. Dates are a nominal 30-year period (0001--0030 on a 365-day calendar), not real calendar dates. | CSV -> Parquet |
 | `climate_scenarios_grid` | C9 | **CH2025 gridded scenarios** -- spatially gridded climate projections. | NetCDF (opt-in) |
-| `climate_scenarios_indoor` | -- | **CH2025 indoor climate** -- hourly indoor-climate scenario series per station, scenario (RCP), and variant, delivered as a single ZIP of CSVs. | CSV+ZIP -> Parquet |
+| `climate_scenarios_indoor` | -- | **CH2025 indoor climate** -- hourly indoor-climate scenario series per station, scenario (RCP), and variant, delivered as a single ZIP of CSVs. | CSV -> Parquet |
 
 ---
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -73,7 +73,7 @@ df = foehn.load("smn", station="BER", frequency="d", sort="desc")
 The CH2025 scenario collections have their own layout but load the same way:
 
 ```python
-# Indoor climate scenarios (CSV+ZIP): the whole archive is fetched once, then
+# Indoor climate scenarios: the whole archive is fetched once, then
 # filtered in memory by station.
 df = foehn.load("climate_scenarios_indoor", station="ABO")
 

--- a/scripts/ingest_delta.py
+++ b/scripts/ingest_delta.py
@@ -30,12 +30,10 @@ from pathlib import Path
 import polars as pl
 from pyspark.sql import SparkSession
 
-from foehn.collections import COLLECTIONS, GRIB2_COLLECTIONS, NETCDF_COLLECTIONS
+from foehn import registry
 from foehn.convert import _load_metadata_types, group_csv_files, parse_csv_bytes
 
-TABULAR_COLLECTIONS = [key for key in COLLECTIONS if key not in GRIB2_COLLECTIONS | NETCDF_COLLECTIONS] + [
-    "climate_normals"
-]
+TABULAR_COLLECTIONS = [*registry.tabular_datasets(), "climate_normals"]
 
 # Collections where historical data can exceed available memory.
 # Chunked ingestion is used for these when --historical is set.

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -8,35 +8,24 @@ from pathlib import Path
 
 import polars as pl
 
+from foehn import registry
 from foehn._urls import asset_filename, clean_href
 from foehn.client import (
     DownloadResult,
     _check_zip_size,
-    download_climate_scenarios_indoor,
-    download_collection,
-    download_grib2,
-    download_metadata,
-    download_netcdf,
 )
 from foehn.collections import (
     COLLECTION_META,
     COLLECTIONS,
-    CSV_ZIP_COLLECTIONS,
-    FORECAST_CSV_COLLECTIONS,
-    GRIB2_COLLECTIONS,
-    NETCDF_COLLECTIONS,
-    NO_GRANULARITY_COLLECTIONS,
-    PREAMBLE_CSV_COLLECTIONS,
+    DatasetKind,
     forecast_run_from_filename,
+    kind,
     time_slice_from_filename,
 )
 from foehn.convert import (
     _parse_metadata_types,
     add_forecast_local_timestamp,
     add_indoor_columns,
-    convert_climate_scenarios_indoor_to_parquet,
-    convert_climate_scenarios_to_parquet,
-    convert_to_parquet,
     decode_meteoswiss_csv,
     parse_climate_scenarios_csv,
     parse_csv_bytes,
@@ -108,27 +97,17 @@ def download(
     bronze_dir.mkdir(parents=True, exist_ok=True)
     fetcher = default_fetcher()
 
-    # Binary/grid datasets have no Parquet path — download the raw assets so the
-    # Python API mirrors the CLI's --grids behaviour (and open_dataset/to_zarr).
-    if dataset in GRIB2_COLLECTIONS:
-        return download_grib2(dataset, bronze_dir, since=since, workers=workers, fetcher=fetcher)
-    if dataset in NETCDF_COLLECTIONS:
-        return download_netcdf(dataset, bronze_dir, since=since, workers=workers, fetcher=fetcher)
-
-    if dataset in CSV_ZIP_COLLECTIONS:
-        return download_climate_scenarios_indoor(bronze_dir, dataset, force=force, fetcher=fetcher)
-
-    meta = download_metadata(dataset, bronze_dir, workers=workers, fetcher=fetcher)
-    coll = download_collection(
-        dataset, bronze_dir, data_types=time_slice or ["recent"], since=since, workers=workers, fetcher=fetcher
-    )
-
-    return DownloadResult(
-        total_assets=meta.total_assets + coll.total_assets,
-        downloaded=meta.downloaded + coll.downloaded,
-        skipped=meta.skipped + coll.skipped,
-        failed=meta.failed + coll.failed,
-        filenames=meta.filenames + coll.filenames,
+    # Each kind knows its own download path, including the grid kinds, which have
+    # no Parquet stage but still fetch their raw assets so the Python API mirrors
+    # the CLI's --grids behaviour (and open_dataset/to_zarr).
+    return registry.download(
+        dataset,
+        bronze_dir,
+        time_slice=time_slice,
+        since=since,
+        workers=workers,
+        force=force,
+        fetcher=fetcher,
     )
 
 
@@ -154,12 +133,7 @@ def to_parquet(
     data_dir = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     bronze_dir = data_dir / "bronze"
     parquet_dir = data_dir / "parquet"
-    if dataset in CSV_ZIP_COLLECTIONS:
-        failures = convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
-    elif dataset in PREAMBLE_CSV_COLLECTIONS:
-        failures = convert_climate_scenarios_to_parquet(bronze_dir, parquet_dir)
-    else:
-        failures = convert_to_parquet(dataset, bronze_dir, parquet_dir)
+    failures = registry.convert(dataset, bronze_dir, parquet_dir)
     if failures:
         raise RuntimeError(
             f"to_parquet({dataset!r}) failed: {failures} group(s) did not convert. See stdout for details."
@@ -571,11 +545,18 @@ def load(
     """
     if dataset not in COLLECTIONS:
         raise ValueError(f"Unknown dataset: {dataset!r}. Use list_datasets() to see available datasets.")
-    if dataset in GRIB2_COLLECTIONS or dataset in NETCDF_COLLECTIONS:
+    spec = registry.spec(dataset)
+    if not spec.tabular:
         raise ValueError(f"Dataset {dataset!r} is a binary/grid dataset and cannot be loaded as a DataFrame.")
-    if dataset in CSV_ZIP_COLLECTIONS:
-        if frequency is not None:
-            raise ValueError(f"Dataset {dataset!r} does not support frequency filtering.")
+    if frequency is not None and not spec.supports_granularity:
+        raise ValueError(f"Dataset {dataset!r} does not support frequency filtering.")
+    if not spec.supports_calendar_filters and any(x is not None for x in (year, month, date_from, date_to)):
+        raise ValueError(
+            f"Dataset {dataset!r} uses nominal 30-year dates (0001..0030); "
+            "year/month/date_from/date_to filters are not supported."
+        )
+
+    if kind(dataset) is DatasetKind.ARCHIVE_CSV:
         return _load_indoor(
             dataset,
             station=station,
@@ -589,14 +570,7 @@ def load(
             limit=limit,
         )
 
-    if dataset in PREAMBLE_CSV_COLLECTIONS:
-        if frequency is not None:
-            raise ValueError(f"Dataset {dataset!r} does not support frequency filtering.")
-        if any(x is not None for x in (year, month, date_from, date_to)):
-            raise ValueError(
-                f"Dataset {dataset!r} uses nominal 30-year dates (0001..0030); "
-                "year/month/date_from/date_to filters are not supported."
-            )
+    if kind(dataset) is DatasetKind.PREAMBLE_CSV:
         return _load_climate_scenarios(
             dataset,
             station=station,
@@ -623,8 +597,6 @@ def load(
     # Normalise frequency filter to a set (e.g. {"d", "h"}).
     freq_filter: set[str] | None = None
     if frequency is not None:
-        if dataset in NO_GRANULARITY_COLLECTIONS:
-            raise ValueError(f"Dataset {dataset!r} does not support frequency filtering.")
         if isinstance(frequency, str):
             freq_filter = {frequency.lower()}
         else:
@@ -653,10 +625,10 @@ def load(
     # until that day's runs publish — so keep all items and narrow to the newest
     # run by filename below. Ranking on ``datetime`` would not help either: it is a
     # refresh timestamp, identical across items to the microsecond.
-    if dataset in FORECAST_CSV_COLLECTIONS and items:
+    if kind(dataset) is DatasetKind.FORECAST_CSV and items:
         items.sort(key=lambda x: x.get("id", ""))
 
-    skip_data_type_filter = dataset in FORECAST_CSV_COLLECTIONS
+    skip_data_type_filter = kind(dataset) is DatasetKind.FORECAST_CSV
     csv_hrefs: list[str] = []
     for item in items:
         assets = item.get("assets", {})
@@ -680,7 +652,7 @@ def load(
 
     # Narrow forecasts to the newest model run — the retained window holds ~40 runs
     # of ~32 files each, and load() wants the current forecast, not all of them.
-    if dataset in FORECAST_CSV_COLLECTIONS and csv_hrefs:
+    if kind(dataset) is DatasetKind.FORECAST_CSV and csv_hrefs:
         runs = {run for href in csv_hrefs if (run := forecast_run_from_filename(clean_href(href))) is not None}
         if runs:
             latest_run = max(runs)

--- a/src/foehn/cli.py
+++ b/src/foehn/cli.py
@@ -10,29 +10,16 @@ from pathlib import Path
 
 import polars as pl
 
+from foehn import registry
 from foehn.api import inventory, list_datasets, parameters, stations
 from foehn.client import (
     download_climate_normals_zip,
-    download_climate_scenarios_indoor,
-    download_collection,
-    download_grib2,
-    download_metadata,
-    download_netcdf,
     load_last_run,
     save_last_run,
 )
-from foehn.collections import (
-    COLLECTIONS,
-    CSV_ZIP_COLLECTIONS,
-    GRIB2_COLLECTIONS,
-    NETCDF_COLLECTIONS,
-    PREAMBLE_CSV_COLLECTIONS,
-)
+from foehn.collections import COLLECTIONS
 from foehn.convert import (
     convert_climate_normals_to_parquet,
-    convert_climate_scenarios_indoor_to_parquet,
-    convert_climate_scenarios_to_parquet,
-    convert_to_parquet,
 )
 from foehn.fetch import default_fetcher
 
@@ -75,7 +62,7 @@ def _resolve_datasets(datasets: list[str], *, allow_grids: bool = False) -> list
     # Default: all collections (skip grids unless opted in)
     if allow_grids:
         return list(COLLECTIONS)
-    return [k for k in COLLECTIONS if k not in GRIB2_COLLECTIONS and k not in NETCDF_COLLECTIONS]
+    return registry.tabular_datasets()
 
 
 def cmd_list(args: argparse.Namespace) -> None:
@@ -146,26 +133,17 @@ def cmd_download(args: argparse.Namespace) -> None:
     failures = 0
     download_failures = 0
     for ds in datasets:
-        if ds in GRIB2_COLLECTIONS:
-            download_failures += download_grib2(ds, bronze_dir, since=since, workers=workers, fetcher=fetcher).failed
-        elif ds in NETCDF_COLLECTIONS:
-            download_failures += download_netcdf(ds, bronze_dir, since=since, workers=workers, fetcher=fetcher).failed
-        elif ds in CSV_ZIP_COLLECTIONS:
-            download_failures += download_climate_scenarios_indoor(
-                bronze_dir, ds, force=full_refresh, fetcher=fetcher
-            ).failed
-            if not args.no_parquet:
-                failures += convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
-        else:
-            download_failures += download_metadata(ds, bronze_dir, workers=workers, fetcher=fetcher).failed
-            download_failures += download_collection(
-                ds, bronze_dir, data_types=time_slices, since=since, workers=workers, fetcher=fetcher
-            ).failed
-            if not args.no_parquet:
-                if ds in PREAMBLE_CSV_COLLECTIONS:
-                    failures += convert_climate_scenarios_to_parquet(bronze_dir, parquet_dir)
-                else:
-                    failures += convert_to_parquet(ds, bronze_dir, parquet_dir)
+        download_failures += registry.download(
+            ds,
+            bronze_dir,
+            time_slice=time_slices,
+            since=since,
+            workers=workers,
+            force=full_refresh,
+            fetcher=fetcher,
+        ).failed
+        if not args.no_parquet:
+            failures += registry.convert(ds, bronze_dir, parquet_dir)
 
     # C6 climate normals (ZIP from opendata.swiss, not STAC)
     if not args.datasets:
@@ -207,15 +185,7 @@ def cmd_to_parquet(args: argparse.Namespace) -> None:
 
     failures = 0
     for ds in datasets:
-        if ds in GRIB2_COLLECTIONS or ds in NETCDF_COLLECTIONS:
-            continue
-        if ds in CSV_ZIP_COLLECTIONS:
-            failures += convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
-            continue
-        if ds in PREAMBLE_CSV_COLLECTIONS:
-            failures += convert_climate_scenarios_to_parquet(bronze_dir, parquet_dir)
-            continue
-        failures += convert_to_parquet(ds, bronze_dir, parquet_dir)
+        failures += registry.convert(ds, bronze_dir, parquet_dir)
 
     if not args.datasets:
         failures += convert_climate_normals_to_parquet(bronze_dir, parquet_dir)

--- a/src/foehn/client.py
+++ b/src/foehn/client.py
@@ -14,8 +14,9 @@ from foehn._urls import asset_filename, clean_href
 from foehn.collections import (
     CLIMATE_NORMALS_ZIP_URL,
     COLLECTIONS,
-    FORECAST_CSV_COLLECTIONS,
+    DatasetKind,
     forecast_run_from_filename,
+    kind,
     time_slice_from_filename,
 )
 from foehn.convert import utf8_meteoswiss_csv
@@ -207,7 +208,7 @@ def download_collection(
     # Collect matching CSV assets. ``all_csv_hrefs`` is the full pre-filter set
     # (every CSV in the listing, regardless of time slice) — the prune universe
     # below, so ETags for slices outside this run's data_types are kept.
-    skip_data_type_filter = collection_key in FORECAST_CSV_COLLECTIONS
+    skip_data_type_filter = kind(collection_key) is DatasetKind.FORECAST_CSV
     csv_assets = []
     all_csv_hrefs: set[str] = set()
     for item in items:
@@ -226,7 +227,7 @@ def download_collection(
 
     # One forecast run is ~32 files at ~30 MB each (~1 GB); the full retained
     # window is ~40 runs (~40 GB). Keep only the newest complete-ish run.
-    if collection_key in FORECAST_CSV_COLLECTIONS and csv_assets:
+    if kind(collection_key) is DatasetKind.FORECAST_CSV and csv_assets:
         runs = {run for href, _ in csv_assets if (run := forecast_run_from_filename(clean_href(href))) is not None}
         if runs:
             latest_run = max(runs)

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -99,6 +99,7 @@ format — this is what each foehn reader relies on:
 """
 
 import re
+from enum import StrEnum
 
 STAC_API_BASE = "https://data.geo.admin.ch/api/stac/v1"
 
@@ -302,7 +303,7 @@ COLLECTION_META: dict[str, dict] = {
         "category": "C",
         "subcategory": "C",
         "description": "Indoor climate scenarios (hourly)",
-        "format": "CSV+ZIP",
+        "format": "CSV",
         "frequencies": [],
         "time_slices": [],
     },
@@ -362,51 +363,93 @@ COLLECTION_META: dict[str, dict] = {
 # A collection belongs to at most one of these sets.
 # Everything not in any set is treated as a CSV collection (downloaded + Parquet).
 
+
 # CSV collections that DON'T use "recent"/"historical"/"now" filename suffixes.
 # These get all CSVs regardless of data_types filter. Only latest item is kept.
-FORECAST_CSV_COLLECTIONS = {"forecast_local"}
+class DatasetKind(StrEnum):
+    """Which pipeline handles a dataset: its download, convert and load paths.
 
-# Collections whose CSV filenames do NOT follow the standard
-# ogd-{key}_{station}_{granularity}[_{timeslice}].csv pattern.
-# Granularity filtering is not supported for these.
-NO_GRANULARITY_COLLECTIONS = {"forecast_local", "climate_scenarios"}
+    Distinct from ``format`` in COLLECTION_META, which says what the *bytes* are
+    and is public. Several kinds share one format — smn, climate_scenarios and
+    forecast_local are all CSV but need three different readers — so format
+    cannot carry the routing. Kind is internal; nothing surfaces it to callers.
+    """
 
-# Binary grid collections (HDF5/GRIB2). Large, opt-in via --grids flag.
-# Downloaded as binary blobs, NOT converted to Parquet.
-GRIB2_COLLECTIONS = {
-    "forecast_icon_ch1",
-    "forecast_icon_ch2",
-    "analysis_kenda_ch1",
-    "radar_precip",
-    "radar_hail",
+    STANDARD_CSV = "standard_csv"
+    """Per-station CSV assets split by time slice and granularity. The main path."""
+
+    PREAMBLE_CSV = "preamble_csv"
+    """CSV behind a ``KEY;VALUE`` metadata preamble, on nominal 30-year dates."""
+
+    ARCHIVE_CSV = "archive_csv"
+    """A single ZIP of per-station CSVs rather than per-station STAC assets."""
+
+    FORECAST_CSV = "forecast_csv"
+    """Point forecasts named by run, with no time slice and no reference_timestamp."""
+
+    NETCDF_GRID = "netcdf_grid"
+    """Static gridded analyses, normals and scenarios. Combines across files."""
+
+    GRIB2_GRID = "grib2_grid"
+    """ICON/KENDA on an unstructured grid, one field per file."""
+
+    RADAR_GRID = "radar_grid"
+    """ODIM-H5 Cartesian composites, one per timestep."""
+
+
+# One row per dataset. Adding a collection means adding it here and to
+# COLLECTIONS; a kind missing from either is caught by the tests.
+KIND_OF: dict[str, DatasetKind] = {
+    # A: ground-based measurements
+    "smn": DatasetKind.STANDARD_CSV,
+    "smn_precip": DatasetKind.STANDARD_CSV,
+    "smn_tower": DatasetKind.STANDARD_CSV,
+    "nime": DatasetKind.STANDARD_CSV,
+    "tot": DatasetKind.STANDARD_CSV,
+    "obs": DatasetKind.STANDARD_CSV,
+    "pollen": DatasetKind.STANDARD_CSV,
+    "phenology": DatasetKind.STANDARD_CSV,
+    # C: climate
+    "nbcn": DatasetKind.STANDARD_CSV,
+    "nbcn_precip": DatasetKind.STANDARD_CSV,
+    "surface_derived_grid": DatasetKind.NETCDF_GRID,
+    "satellite_derived_grid": DatasetKind.NETCDF_GRID,
+    "radar_derived_grid": DatasetKind.NETCDF_GRID,
+    "climate_normals_grid": DatasetKind.NETCDF_GRID,
+    "climate_scenarios_grid": DatasetKind.NETCDF_GRID,
+    "climate_scenarios": DatasetKind.PREAMBLE_CSV,
+    "climate_scenarios_indoor": DatasetKind.ARCHIVE_CSV,
+    # D: radar
+    "radar_precip": DatasetKind.RADAR_GRID,
+    "radar_hail": DatasetKind.RADAR_GRID,
+    # E: forecasts
+    "forecast_icon_ch1": DatasetKind.GRIB2_GRID,
+    "forecast_icon_ch2": DatasetKind.GRIB2_GRID,
+    "analysis_kenda_ch1": DatasetKind.GRIB2_GRID,
+    "forecast_local": DatasetKind.FORECAST_CSV,
 }
 
-# Spatial/static collections (NetCDF, GeoTIFF, ZIP). Always downloaded.
-# NOT converted to Parquet — these are gridded/spatial data, not tabular.
-NETCDF_COLLECTIONS = {
-    "surface_derived_grid",
-    "satellite_derived_grid",
-    "radar_derived_grid",
-    "climate_scenarios_grid",
-    "climate_normals_grid",
-}
+# The kinds read as grids rather than tabular frames.
+GRID_KINDS = frozenset({DatasetKind.NETCDF_GRID, DatasetKind.GRIB2_GRID, DatasetKind.RADAR_GRID})
 
-# Tabular collections delivered as a single ZIP of CSVs (not per-station STAC
-# assets), with their own separator/timestamp layout. Like the C6 climate
-# normals, these get a bespoke download+convert path rather than the standard
-# CSV flow.
-CSV_ZIP_COLLECTIONS = {
-    "climate_scenarios_indoor",
-}
+# Kinds whose filenames do not carry the standard
+# ogd-{key}_{station}_{granularity}[_{timeslice}].csv pattern, so there is no
+# granularity to filter on. Derived from the kind rather than listed separately,
+# which is what NO_GRANULARITY_COLLECTIONS used to be.
+NO_GRANULARITY_KINDS = frozenset({DatasetKind.PREAMBLE_CSV, DatasetKind.FORECAST_CSV})
 
-# CSV collections whose files carry a multi-row "KEY;VALUE" metadata preamble
-# before the real "DATE;<model>;..." table (CH2025 climate scenarios). The
-# standard reader would treat the preamble as the header, so these need a
-# preamble-skipping parser. Downloads are standard per-file CSVs; only the
-# parse differs.
-PREAMBLE_CSV_COLLECTIONS = {
-    "climate_scenarios",
-}
+
+def kind(dataset: str) -> DatasetKind:
+    """Return a dataset's :class:`DatasetKind`.
+
+    Raises KeyError for an unknown dataset, same as ``COLLECTIONS[dataset]``.
+    """
+    return KIND_OF[dataset]
+
+
+def is_grid(dataset: str) -> bool:
+    """True if *dataset* is read as a grid (xarray) rather than a DataFrame."""
+    return KIND_OF[dataset] in GRID_KINDS
 
 
 # (The gridded read path's per-format engine/suffix config now lives in

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -275,7 +275,7 @@ def group_csv_files(csv_dir: Path, collection_key: str) -> dict[tuple[str, ...],
     must agree with the Parquet converter on where the boundaries are — these
     are upstream naming rules, and two copies of them drift.
     """
-    from foehn.collections import COLLECTIONS, NO_GRANULARITY_COLLECTIONS
+    from foehn.collections import COLLECTIONS, NO_GRANULARITY_KINDS, kind
 
     csv_files = [f for f in sorted(csv_dir.glob("*.csv")) if "_meta_" not in f.name]
     groups: dict[tuple[str, ...], list[Path]] = {}
@@ -283,7 +283,7 @@ def group_csv_files(csv_dir: Path, collection_key: str) -> dict[tuple[str, ...],
     # No granularity in the filename at all (forecast_local's vnut12.lssw.* names,
     # climate_scenarios). Returning early also avoids slicing off a prefix these
     # names do not carry, which would chop arbitrary characters off the stem.
-    if collection_key in NO_GRANULARITY_COLLECTIONS:
+    if kind(collection_key) in NO_GRANULARITY_KINDS:
         if csv_files:
             groups[()] = csv_files
         return groups

--- a/src/foehn/grids.py
+++ b/src/foehn/grids.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from foehn._urls import asset_filename, clean_href
-from foehn.collections import COLLECTION_META, COLLECTIONS
+from foehn.collections import COLLECTION_META, COLLECTIONS, KIND_OF, DatasetKind, is_grid, kind
 from foehn.fetch import DEFAULT_WORKERS, Fetcher, FetchError, default_fetcher
 
 logger = logging.getLogger(__name__)
@@ -89,9 +89,7 @@ def _require_radar_deps():
         ) from exc
 
 
-# Per-format read configuration, keyed off COLLECTION_META's "format". Routing
-# uses this rather than the GRIB2_COLLECTIONS set, which lumps GRIB2 and HDF5
-# together. NetCDF keeps engine=None so xarray auto-detects NetCDF-3 vs -4/HDF5;
+# Per-kind read configuration. NetCDF keeps engine=None so xarray auto-detects NetCDF-3 vs -4/HDF5;
 # GRIB2 forces cfgrib and disables its .idx sidecar files (indexpath=""); HDF5
 # radar uses a bespoke ODIM-composite reader (``reader="odim"``) instead of an
 # xarray engine.
@@ -104,16 +102,22 @@ def _require_radar_deps():
 # build cubes.) ``match_example`` seeds the "narrow your match" guidance. The cap
 # is checked against the *remote* listing before downloading, so an over-broad
 # match is rejected even when one matching file already happens to be cached.
-_GRID_READERS: dict[str, dict] = {
-    "NetCDF": {"suffixes": (".nc",), "engine": None, "backend_kwargs": None, "max_files": None, "match_example": None},
-    "GRIB2": {
+_GRID_READERS: dict[DatasetKind, dict] = {
+    DatasetKind.NETCDF_GRID: {
+        "suffixes": (".nc",),
+        "engine": None,
+        "backend_kwargs": None,
+        "max_files": None,
+        "match_example": None,
+    },
+    DatasetKind.GRIB2_GRID: {
         "suffixes": (".grib2", ".grib"),
         "engine": "cfgrib",
         "backend_kwargs": {"indexpath": ""},
         "max_files": 1,
         "match_example": "202605231500-0-t_2m-ctrl",
     },
-    "HDF5": {
+    DatasetKind.RADAR_GRID: {
         "suffixes": (".h5",),
         "reader": "odim",
         "engine": None,
@@ -152,7 +156,7 @@ def _run_datetime_filter(collection_key: str, match: str | None) -> str | None:
     data date matches nothing. Those listings are small anyway (radar_precip is
     16 items), so they lose nothing by walking in full.
     """
-    if match is None or COLLECTION_META.get(collection_key, {}).get("format") != "GRIB2":
+    if match is None or KIND_OF.get(collection_key) is not DatasetKind.GRIB2_GRID:
         return None
     found = _RUN_STAMP_RE.search(match)
     if not found:
@@ -511,9 +515,9 @@ def _validate_grid_dataset(dataset: str) -> None:
     """Guard shared by open_dataset/to_zarr. Allows NetCDF/GRIB2/HDF5 grids; rejects tabular."""
     if dataset not in COLLECTIONS:
         raise ValueError(f"Unknown dataset: {dataset!r}. Use list_datasets() to see available datasets.")
-    fmt = COLLECTION_META[dataset]["format"]
-    if fmt in _GRID_READERS:
+    if is_grid(dataset):
         return
+    fmt = COLLECTION_META[dataset]["format"]
     raise ValueError(f"Dataset {dataset!r} is tabular ({fmt}). Use foehn.load() to get a Polars DataFrame instead.")
 
 
@@ -594,13 +598,14 @@ def open_dataset(
     """
     _validate_grid_dataset(dataset)
     fetcher = default_fetcher()
+    dataset_kind = kind(dataset)
     fmt = COLLECTION_META[dataset]["format"]
-    reader = _GRID_READERS[fmt]
+    reader = _GRID_READERS[dataset_kind]
 
     xr = _require_xarray()
-    if fmt == "GRIB2":
+    if dataset_kind is DatasetKind.GRIB2_GRID:
         _require_cfgrib()
-    elif fmt == "HDF5":
+    elif dataset_kind is DatasetKind.RADAR_GRID:
         _require_radar_deps()
 
     # Single-file formats (GRIB2, radar) have thousands of files per collection,
@@ -638,7 +643,7 @@ def open_dataset(
         # the GRIB). Attach cell lat/lon from the collection's constants file so
         # the data is geo-referenced. Best-effort: warn and continue if it's
         # unavailable (e.g. offline) rather than failing an otherwise-good read.
-        if fmt == "GRIB2" and "values" in ds.dims and "lat" not in ds.coords:
+        if dataset_kind is DatasetKind.GRIB2_GRID and "values" in ds.dims and "lat" not in ds.coords:
             try:
                 lat, lon = _icon_unstructured_lonlat(dataset, bronze_dir, fetcher=fetcher)
                 if lat is not None and lon is not None and lat.size == ds.sizes["values"]:
@@ -698,14 +703,14 @@ def _write_zarr(ds, store: Path, mode: str, append_dim: str | None = None) -> No
             ds.to_zarr(store, mode=mode)
 
 
-def _to_zarr_stacked(dataset, fmt, *, variables, match, data_dir, store, mode, fetcher) -> Path:
+def _to_zarr_stacked(dataset, dataset_kind, fmt, *, variables, match, data_dir, store, mode, fetcher) -> Path:
     """Stack a matched set of radar composites into one ``(time, y, x)`` Zarr cube.
 
     Written incrementally — one timestep appended at a time along ``time`` — so
     peak memory stays at a single file no matter how many timesteps the match
     spans, and no dask is needed.
     """
-    if fmt != "HDF5":
+    if dataset_kind is not DatasetKind.RADAR_GRID:
         raise ValueError(
             f"stack='time' is only supported for radar (HDF5) collections; {dataset!r} is {fmt}. "
             "NetCDF multi-file matches already combine via match=; GRIB2 uses stack='auto'."
@@ -718,7 +723,7 @@ def _to_zarr_stacked(dataset, fmt, *, variables, match, data_dir, store, mode, f
 
     xr = _require_xarray()
     _require_radar_deps()
-    reader = _GRID_READERS[fmt]
+    reader = _GRID_READERS[dataset_kind]
 
     root = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     # No single-file cap here: stacking deliberately wants the whole matched set.
@@ -749,7 +754,7 @@ def _to_zarr_stacked(dataset, fmt, *, variables, match, data_dir, store, mode, f
 _HYPERCUBE_MAX_FILES = 1000
 
 
-def _to_zarr_hypercube(dataset, fmt, *, variables, match, data_dir, store, mode, fetcher) -> Path:
+def _to_zarr_hypercube(dataset, dataset_kind, fmt, *, variables, match, data_dir, store, mode, fetcher) -> Path:
     """Combine matched GRIB2 files into one N-D cube over their varying axes.
 
     Each ICON/KENDA file is a single (variable, member, lead time, reference time)
@@ -759,7 +764,7 @@ def _to_zarr_hypercube(dataset, fmt, *, variables, match, data_dir, store, mode,
     derived ``valid_time`` is dropped before combining (it conflicts on concat)
     and recomputed afterwards. The whole set is loaded into memory at once.
     """
-    if fmt != "GRIB2":
+    if dataset_kind is not DatasetKind.GRIB2_GRID:
         raise ValueError(
             f"stack='auto' is only supported for GRIB2 collections; {dataset!r} is {fmt}. "
             "Radar uses stack='time'; NetCDF multi-file matches already combine via match=."
@@ -772,7 +777,7 @@ def _to_zarr_hypercube(dataset, fmt, *, variables, match, data_dir, store, mode,
 
     xr = _require_xarray()
     _require_cfgrib()
-    reader = _GRID_READERS[fmt]
+    reader = _GRID_READERS[dataset_kind]
 
     root = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     bronze_dir = root / "bronze"
@@ -874,6 +879,7 @@ def to_zarr(
         Path to the written ``.zarr`` store.
     """
     _validate_grid_dataset(dataset)
+    dataset_kind = kind(dataset)
     fmt = COLLECTION_META[dataset]["format"]
 
     if stack is not None:
@@ -890,10 +896,10 @@ def to_zarr(
             "fetcher": default_fetcher(),
         }
         # "auto" routes to each format's best cube builder; "time" is the explicit radar path.
-        if stack == "time" or fmt == "HDF5":
-            return _to_zarr_stacked(dataset, fmt, **kwargs)  # radar: incremental (time, y, x)
-        if fmt == "GRIB2":
-            return _to_zarr_hypercube(dataset, fmt, **kwargs)  # forecasts: N-D combine_by_coords
+        if stack == "time" or dataset_kind is DatasetKind.RADAR_GRID:
+            return _to_zarr_stacked(dataset, dataset_kind, fmt, **kwargs)  # radar: incremental (time, y, x)
+        if dataset_kind is DatasetKind.GRIB2_GRID:
+            return _to_zarr_hypercube(dataset, dataset_kind, fmt, **kwargs)  # forecasts: N-D combine_by_coords
         # NetCDF + stack="auto": open_dataset already combines a multi-file match,
         # so just fall through to the normal single-write path below.
 

--- a/src/foehn/mcp_server.py
+++ b/src/foehn/mcp_server.py
@@ -18,17 +18,13 @@ from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 import foehn
-from foehn.collections import (
-    COLLECTION_META,
-    COLLECTIONS,
-    GRIB2_COLLECTIONS,
-    NETCDF_COLLECTIONS,
-)
+from foehn import registry
+from foehn.collections import COLLECTION_META, COLLECTIONS
 
 logger = logging.getLogger(__name__)
 
 # Datasets that can be loaded as tabular data (CSV-backed).
-_LOADABLE_DATASETS = sorted(k for k in COLLECTIONS if k not in GRIB2_COLLECTIONS and k not in NETCDF_COLLECTIONS)
+_LOADABLE_DATASETS = sorted(registry.tabular_datasets())
 _VALID_FREQUENCIES = {"t", "h", "d", "m", "y"}
 _VALID_TIME_SLICES = {"historical", "recent", "now"}
 _VALID_CATEGORIES = {"A", "C", "D", "E"}
@@ -52,10 +48,10 @@ _GRID_INSPECT = ToolAnnotations(
     open_world_hint=True,
 )
 
-# Gridded collections describe_grid can inspect: every NetCDF, GRIB2, and HDF5
-# (radar) collection (GRIB2_COLLECTIONS holds both GRIB2 and radar). GRIB2/radar
-# additionally require a single-file match=, enforced by open_dataset.
-_INSPECTABLE_GRIDS = sorted(NETCDF_COLLECTIONS | GRIB2_COLLECTIONS)
+# Gridded collections describe_grid can inspect: every NetCDF, GRIB2 and radar
+# dataset. GRIB2/radar additionally require a single-file match=, enforced by
+# open_dataset.
+_INSPECTABLE_GRIDS = sorted(registry.grid_datasets())
 
 mcp = MCPServer(
     "foehn",
@@ -284,7 +280,7 @@ def load_data(
     """
     if dataset not in COLLECTIONS:
         raise ValueError(f"Unknown dataset {dataset!r}. Call list_datasets() to see options.")
-    if dataset in GRIB2_COLLECTIONS or dataset in NETCDF_COLLECTIONS:
+    if not registry.spec(dataset).tabular:
         fmt = COLLECTION_META[dataset]["format"]
         raise ValueError(f"Dataset {dataset!r} is {fmt} (binary/grid) and cannot be loaded as tabular data.")
     if frequency and frequency.lower() not in _VALID_FREQUENCIES:
@@ -354,7 +350,7 @@ def describe_data(
     """
     if dataset not in COLLECTIONS:
         raise ValueError(f"Unknown dataset {dataset!r}. Call list_datasets() to see options.")
-    if dataset in GRIB2_COLLECTIONS or dataset in NETCDF_COLLECTIONS:
+    if not registry.spec(dataset).tabular:
         fmt = COLLECTION_META[dataset]["format"]
         raise ValueError(f"Dataset {dataset!r} is {fmt} (binary/grid) and cannot be described.")
     if frequency and frequency.lower() not in _VALID_FREQUENCIES:

--- a/src/foehn/registry.py
+++ b/src/foehn/registry.py
@@ -1,0 +1,219 @@
+"""What each :class:`~foehn.collections.DatasetKind` can do, and who does it.
+
+One table replacing the routing ladders that used to sit in ``api``, ``cli`` and
+the Databricks ingest script, each re-deriving from a different set of dataset
+keys. Callers ask the registry instead of testing membership.
+
+Layering: ``collections`` (dataset facts) → ``client``/``convert`` (adapters) →
+this module → ``api``/``cli``/``mcp_server``. The load readers deliberately stay
+in ``api``: they are its implementation, and hoisting them here just to fill a
+column would invert that dependency. What the registry says about loading is
+which filters a kind supports, which is a fact about the data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from foehn.client import (
+    DownloadResult,
+    download_climate_scenarios_indoor,
+    download_collection,
+    download_grib2,
+    download_metadata,
+    download_netcdf,
+)
+from foehn.collections import COLLECTIONS, KIND_OF, DatasetKind, kind
+from foehn.convert import (
+    convert_climate_scenarios_indoor_to_parquet,
+    convert_climate_scenarios_to_parquet,
+    convert_to_parquet,
+)
+from foehn.fetch import DEFAULT_WORKERS, Fetcher
+
+# Every download adapter takes the same arguments and ignores what its kind does
+# not use, so callers never have to know which ones apply. The alternative — a
+# per-kind call shape — is the ladder we are removing.
+DownloadAdapter = Callable[..., DownloadResult]
+ConvertAdapter = Callable[[str, Path, Path], int]
+
+
+def _download_standard(
+    dataset: str,
+    bronze_dir: Path,
+    *,
+    time_slice: list[str],
+    since: str | None,
+    workers: int,
+    force: bool,
+    fetcher: Fetcher,
+) -> DownloadResult:
+    """Collection-level metadata plus the per-station CSVs, as one result.
+
+    Both callers previously did this pairing themselves — ``api.download``
+    summing the two results, the CLI adding their ``failed`` counts separately.
+    """
+    meta = download_metadata(dataset, bronze_dir, workers=workers, fetcher=fetcher)
+    coll = download_collection(
+        dataset, bronze_dir, data_types=time_slice, since=since, workers=workers, fetcher=fetcher
+    )
+    return DownloadResult(
+        total_assets=meta.total_assets + coll.total_assets,
+        downloaded=meta.downloaded + coll.downloaded,
+        skipped=meta.skipped + coll.skipped,
+        failed=meta.failed + coll.failed,
+        filenames=meta.filenames + coll.filenames,
+    )
+
+
+def _download_archive(dataset: str, bronze_dir: Path, *, force: bool, fetcher: Fetcher, **_: object) -> DownloadResult:
+    return download_climate_scenarios_indoor(bronze_dir, dataset, force=force, fetcher=fetcher)
+
+
+def _download_grib2(
+    dataset: str, bronze_dir: Path, *, since: str | None, workers: int, fetcher: Fetcher, **_: object
+) -> DownloadResult:
+    return download_grib2(dataset, bronze_dir, since=since, workers=workers, fetcher=fetcher)
+
+
+def _download_netcdf(
+    dataset: str, bronze_dir: Path, *, since: str | None, workers: int, fetcher: Fetcher, **_: object
+) -> DownloadResult:
+    return download_netcdf(dataset, bronze_dir, since=since, workers=workers, fetcher=fetcher)
+
+
+def _convert_standard(dataset: str, bronze_dir: Path, parquet_dir: Path) -> int:
+    return convert_to_parquet(dataset, bronze_dir, parquet_dir)
+
+
+def _convert_preamble(_dataset: str, bronze_dir: Path, parquet_dir: Path) -> int:
+    return convert_climate_scenarios_to_parquet(bronze_dir, parquet_dir)
+
+
+def _convert_archive(_dataset: str, bronze_dir: Path, parquet_dir: Path) -> int:
+    return convert_climate_scenarios_indoor_to_parquet(bronze_dir, parquet_dir)
+
+
+@dataclass(frozen=True)
+class KindSpec:
+    """Everything the routing needs to know about one kind.
+
+    ``convert`` is None for the grid kinds: they have no Parquet path at all,
+    which is a fact about the kind rather than a branch each caller re-derives.
+    """
+
+    download: DownloadAdapter
+    convert: ConvertAdapter | None
+    tabular: bool
+    """Loadable as a Polars DataFrame. False for the grid kinds (use open_dataset)."""
+
+    supports_granularity: bool
+    """Whether ``frequency=`` applies — false where filenames carry no granularity."""
+
+    supports_calendar_filters: bool
+    """Whether year/month/date_from/date_to apply. False for nominal 30-year dates."""
+
+    key_columns: tuple[str, ...] = ("station_abbr", "reference_timestamp")
+    """Columns an explicit ``columns=`` selection always keeps."""
+
+
+KINDS: dict[DatasetKind, KindSpec] = {
+    DatasetKind.STANDARD_CSV: KindSpec(
+        download=_download_standard,
+        convert=_convert_standard,
+        tabular=True,
+        supports_granularity=True,
+        supports_calendar_filters=True,
+    ),
+    DatasetKind.PREAMBLE_CSV: KindSpec(
+        download=_download_standard,
+        convert=_convert_preamble,
+        tabular=True,
+        supports_granularity=False,
+        # Dates are nominal (0001..0030 on a 365-day calendar), so the calendar
+        # filters would silently match nothing.
+        supports_calendar_filters=False,
+        key_columns=("station_abbr", "variable", "gwl", "date"),
+    ),
+    DatasetKind.ARCHIVE_CSV: KindSpec(
+        download=_download_archive,
+        convert=_convert_archive,
+        tabular=True,
+        supports_granularity=False,
+        supports_calendar_filters=True,
+        key_columns=("station_abbr", "reference_timestamp", "period", "scenario", "variant"),
+    ),
+    DatasetKind.FORECAST_CSV: KindSpec(
+        download=_download_standard,
+        convert=_convert_standard,
+        tabular=True,
+        supports_granularity=False,
+        supports_calendar_filters=True,
+    ),
+    DatasetKind.NETCDF_GRID: KindSpec(
+        download=_download_netcdf,
+        convert=None,
+        tabular=False,
+        supports_granularity=False,
+        supports_calendar_filters=False,
+    ),
+    DatasetKind.GRIB2_GRID: KindSpec(
+        download=_download_grib2,
+        convert=None,
+        tabular=False,
+        supports_granularity=False,
+        supports_calendar_filters=False,
+    ),
+    DatasetKind.RADAR_GRID: KindSpec(
+        download=_download_grib2,
+        convert=None,
+        tabular=False,
+        supports_granularity=False,
+        supports_calendar_filters=False,
+    ),
+}
+
+
+def spec(dataset: str) -> KindSpec:
+    """Return the :class:`KindSpec` for *dataset*."""
+    return KINDS[kind(dataset)]
+
+
+def download(
+    dataset: str,
+    bronze_dir: Path,
+    *,
+    time_slice: list[str] | None = None,
+    since: str | None = None,
+    workers: int = DEFAULT_WORKERS,
+    force: bool = False,
+    fetcher: Fetcher,
+) -> DownloadResult:
+    """Download *dataset* by whichever path its kind uses."""
+    return spec(dataset).download(
+        dataset,
+        bronze_dir,
+        time_slice=time_slice or ["recent"],
+        since=since,
+        workers=workers,
+        force=force,
+        fetcher=fetcher,
+    )
+
+
+def convert(dataset: str, bronze_dir: Path, parquet_dir: Path) -> int:
+    """Convert *dataset* to Parquet, or return 0 for a kind that has no Parquet path."""
+    converter = spec(dataset).convert
+    return 0 if converter is None else converter(dataset, bronze_dir, parquet_dir)
+
+
+def tabular_datasets() -> list[str]:
+    """Every dataset loadable as a DataFrame, in declaration order."""
+    return [key for key in COLLECTIONS if KINDS[KIND_OF[key]].tabular]
+
+
+def grid_datasets() -> list[str]:
+    """Every dataset read as a grid, in declaration order."""
+    return [key for key in COLLECTIONS if not KINDS[KIND_OF[key]].tabular]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@
 
 import io
 import zipfile
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import polars as pl
 import pytest
@@ -58,23 +58,17 @@ def test_download_unknown_dataset_raises():
         download("nonexistent")
 
 
-@patch("foehn.api.download_grib2")
-def test_download_grib2_dataset_routes_to_handler(mock_dl, tmp_path):
+@pytest.mark.parametrize("dataset", ["smn", "forecast_icon_ch1", "surface_derived_grid", "climate_scenarios_indoor"])
+@patch("foehn.registry.download")
+def test_download_delegates_to_the_registry(mock_dl, dataset, tmp_path):
+    """Whichever kind it is, download() hands it to the registry and returns the result."""
     from foehn.client import DownloadResult
 
     mock_dl.return_value = DownloadResult(total_assets=1, downloaded=1)
-    res = download("forecast_icon_ch1", data_dir=tmp_path)
-    mock_dl.assert_called_once_with("forecast_icon_ch1", tmp_path / "bronze", since=None, workers=8, fetcher=ANY)
-    assert res.downloaded == 1
 
+    res = download(dataset, data_dir=tmp_path)
 
-@patch("foehn.api.download_netcdf")
-def test_download_netcdf_dataset_routes_to_handler(mock_dl, tmp_path):
-    from foehn.client import DownloadResult
-
-    mock_dl.return_value = DownloadResult(total_assets=1, downloaded=1)
-    res = download("surface_derived_grid", data_dir=tmp_path)
-    mock_dl.assert_called_once_with("surface_derived_grid", tmp_path / "bronze", since=None, workers=8, fetcher=ANY)
+    assert mock_dl.call_args.args == (dataset, tmp_path / "bronze")
     assert res.downloaded == 1
 
 
@@ -91,18 +85,8 @@ def _make_indoor_zip(data_names):
     return buf.getvalue()
 
 
-@patch("foehn.api.download_climate_scenarios_indoor")
-def test_download_indoor_routes_to_handler(mock_dl, tmp_path):
-    from foehn.client import DownloadResult
-
-    mock_dl.return_value = DownloadResult(total_assets=1, downloaded=1)
-    res = download("climate_scenarios_indoor", data_dir=tmp_path)
-    mock_dl.assert_called_once_with(tmp_path / "bronze", "climate_scenarios_indoor", force=False, fetcher=ANY)
-    assert res.downloaded == 1
-
-
-@patch("foehn.api.download_climate_scenarios_indoor")
-def test_download_indoor_passes_force(mock_dl, tmp_path):
+@patch("foehn.registry.download")
+def test_download_passes_force_through(mock_dl, tmp_path):
     from foehn.client import DownloadResult
 
     mock_dl.return_value = DownloadResult()
@@ -110,15 +94,8 @@ def test_download_indoor_passes_force(mock_dl, tmp_path):
     assert mock_dl.call_args.kwargs["force"] is True
 
 
-@patch("foehn.api.convert_climate_scenarios_indoor_to_parquet")
-def test_to_parquet_indoor_routes_to_converter(mock_conv, tmp_path):
-    mock_conv.return_value = 0
-    to_parquet("climate_scenarios_indoor", data_dir=tmp_path)
-    mock_conv.assert_called_once_with(tmp_path / "bronze", tmp_path / "parquet")
-
-
-@patch("foehn.api.convert_climate_scenarios_indoor_to_parquet")
-def test_to_parquet_indoor_raises_on_failure(mock_conv, tmp_path):
+@patch("foehn.registry.convert")
+def test_to_parquet_raises_when_the_registry_reports_failures(mock_conv, tmp_path):
     mock_conv.return_value = 1
     with pytest.raises(RuntimeError, match="did not convert"):
         to_parquet("climate_scenarios_indoor", data_dir=tmp_path)
@@ -159,13 +136,6 @@ _CS_CSV = (
     "TITLE;X\nVARIABLE;Daily precipitation sum\nGWL;GWL1.5\n\n"
     "DATE;MODEL_A;MODEL_B\n0001-01-01;0;24.2\n0001-01-02;1.5;0\n"
 )
-
-
-@patch("foehn.api.convert_climate_scenarios_to_parquet")
-def test_to_parquet_climate_scenarios_routes(mock_conv, tmp_path):
-    mock_conv.return_value = 0
-    to_parquet("climate_scenarios", data_dir=tmp_path)
-    mock_conv.assert_called_once_with(tmp_path / "bronze", tmp_path / "parquet")
 
 
 def test_load_climate_scenarios_year_filter_raises():
@@ -298,24 +268,14 @@ def test_load_forecast_local_fetches_only_latest_run(fetcher):
     assert all("202607210600" in url for url in fetched)
 
 
-@patch("foehn.api.download_collection")
-@patch("foehn.api.download_metadata")
-def test_download_calls_underlying_functions(mock_meta, mock_dl, tmp_path):
+@patch("foehn.registry.download")
+def test_download_passes_the_requested_time_slice(mock_dl, tmp_path):
     from foehn.client import DownloadResult
 
-    mock_meta.return_value = DownloadResult(total_assets=1, downloaded=1, skipped=0, filenames=["m.csv"])
-    mock_dl.return_value = DownloadResult(total_assets=2, downloaded=2, skipped=0, filenames=["a.csv", "b.csv"])
+    mock_dl.return_value = DownloadResult()
+    download("smn", data_dir=tmp_path, time_slice=["historical"])
 
-    result = download("smn", data_dir=tmp_path, time_slice=["historical"])
-    mock_meta.assert_called_once_with("smn", tmp_path / "bronze", workers=8, fetcher=ANY)
-    mock_dl.assert_called_once_with(
-        "smn", tmp_path / "bronze", data_types=["historical"], since=None, workers=8, fetcher=ANY
-    )
-
-    assert isinstance(result, DownloadResult)
-    assert result.total_assets == 3
-    assert result.downloaded == 3
-    assert result.filenames == ["m.csv", "a.csv", "b.csv"]
+    assert mock_dl.call_args.kwargs["time_slice"] == ["historical"]
 
 
 def test_to_parquet_unknown_dataset_raises():
@@ -323,14 +283,14 @@ def test_to_parquet_unknown_dataset_raises():
         to_parquet("nonexistent")
 
 
-@patch("foehn.api.convert_to_parquet")
-def test_to_parquet_calls_convert_to_parquet(mock_conv, tmp_path):
+@patch("foehn.registry.convert")
+def test_to_parquet_delegates_to_the_registry(mock_conv, tmp_path):
     mock_conv.return_value = 0
     to_parquet("smn", data_dir=tmp_path)
     mock_conv.assert_called_once_with("smn", tmp_path / "bronze", tmp_path / "parquet")
 
 
-@patch("foehn.api.convert_to_parquet")
+@patch("foehn.registry.convert")
 def test_to_parquet_raises_on_convert_failure(mock_conv, tmp_path):
     """Python API should mirror the CLI: any conversion failure raises, not silent."""
     mock_conv.return_value = 2
@@ -338,7 +298,7 @@ def test_to_parquet_raises_on_convert_failure(mock_conv, tmp_path):
         to_parquet("smn", data_dir=tmp_path)
 
 
-@patch("foehn.api.convert_to_parquet")
+@patch("foehn.registry.convert")
 def test_to_parquet_silent_when_no_failures(mock_conv, tmp_path):
     mock_conv.return_value = 0
     to_parquet("smn", data_dir=tmp_path)  # must not raise
@@ -632,17 +592,19 @@ def test_declared_time_slices_match_what_meteoswiss_publishes():
     missing slice tells callers a slice does not exist when it does — pollen's
     hourly "now" series was invisible this way.
     """
+    from foehn import registry
     from foehn._urls import asset_filename
     from foehn.collections import (
         COLLECTION_META,
         COLLECTIONS,
-        CSV_ZIP_COLLECTIONS,
-        GRIB2_COLLECTIONS,
-        NETCDF_COLLECTIONS,
+        DatasetKind,
+        kind,
         time_slice_from_filename,
     )
 
-    tabular = [k for k in COLLECTIONS if k not in GRIB2_COLLECTIONS | NETCDF_COLLECTIONS | CSV_ZIP_COLLECTIONS]
+    # The archive kind ships one ZIP rather than per-slice CSV assets, so it has
+    # no time slices to compare.
+    tabular = [k for k in registry.tabular_datasets() if kind(k) is not DatasetKind.ARCHIVE_CSV]
     mismatches = {}
     for key in tabular:
         found = set()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,19 +5,17 @@ from unittest.mock import patch
 import polars as pl
 import pytest
 
+from foehn import registry
 from foehn.cli import main
 
+# The CLI no longer knows which handler serves which dataset — the registry does.
+# What is left to stub is the registry's two entry points plus the C6 climate
+# normals, which are not a STAC collection and so have no kind.
 _PATCHES = [
-    "foehn.cli.download_collection",
-    "foehn.cli.download_metadata",
-    "foehn.cli.download_grib2",
-    "foehn.cli.download_netcdf",
+    "foehn.registry.download",
+    "foehn.registry.convert",
     "foehn.cli.download_climate_normals_zip",
-    "foehn.cli.download_climate_scenarios_indoor",
-    "foehn.cli.convert_to_parquet",
     "foehn.cli.convert_climate_normals_to_parquet",
-    "foehn.cli.convert_climate_scenarios_indoor_to_parquet",
-    "foehn.cli.convert_climate_scenarios_to_parquet",
     "foehn.cli.save_last_run",
     "foehn.cli.load_last_run",
 ]
@@ -31,21 +29,22 @@ def _start_mocks():
     for name, mock in zip(_PATCHES, started, strict=True):
         mocks[name.split(".")[-1]] = mock
     mocks["load_last_run"].return_value = None
-    mocks["convert_to_parquet"].return_value = 0
+    mocks["convert"].return_value = 0
     mocks["convert_climate_normals_to_parquet"].return_value = 0
-    mocks["convert_climate_scenarios_indoor_to_parquet"].return_value = 0
-    mocks["convert_climate_scenarios_to_parquet"].return_value = 0
     # cmd_download sums result.failed from each download call to gate _last_run;
-    # give the download mocks a clean (0-failure) DownloadResult by default.
-    for name in (
-        "download_collection",
-        "download_metadata",
-        "download_grib2",
-        "download_netcdf",
-        "download_climate_scenarios_indoor",
-    ):
-        mocks[name].return_value.failed = 0
+    # give the download mock a clean (0-failure) DownloadResult by default.
+    mocks["download"].return_value.failed = 0
     return mocks, patchers
+
+
+def _downloaded(mocks):
+    """Datasets passed to registry.download, in call order."""
+    return [call.args[0] for call in mocks["download"].call_args_list]
+
+
+def _converted(mocks):
+    """Datasets passed to registry.convert, in call order."""
+    return [call.args[0] for call in mocks["convert"].call_args_list]
 
 
 def _run(subcommand, args, tmp_path):
@@ -79,32 +78,32 @@ def _run_without_data_dir(subcommand, args, tmp_path):
 
 def test_default_uses_recent_only(tmp_path):
     mocks = _run("download", [], tmp_path)
-    calls = mocks["download_collection"].call_args_list
-    assert calls, "download_collection should be called"
-    time_slices = calls[0][1]["data_types"]
+    calls = mocks["download"].call_args_list
+    assert calls, "registry.download should be called"
+    time_slices = calls[0].kwargs["time_slice"]
     assert time_slices == ["recent"]
 
 
 def test_now_flag_adds_now(tmp_path):
     mocks = _run("download", ["--now"], tmp_path)
-    calls = mocks["download_collection"].call_args_list
-    time_slices = calls[0][1]["data_types"]
+    calls = mocks["download"].call_args_list
+    time_slices = calls[0].kwargs["time_slice"]
     assert "now" in time_slices
     assert "recent" in time_slices
 
 
 def test_historical_flag_prepends_historical(tmp_path):
     mocks = _run("download", ["--historical"], tmp_path)
-    calls = mocks["download_collection"].call_args_list
-    time_slices = calls[0][1]["data_types"]
+    calls = mocks["download"].call_args_list
+    time_slices = calls[0].kwargs["time_slice"]
     assert time_slices[0] == "historical"
     assert "recent" in time_slices
 
 
 def test_all_time_slices(tmp_path):
     mocks = _run("download", ["--now", "--historical"], tmp_path)
-    calls = mocks["download_collection"].call_args_list
-    time_slices = calls[0][1]["data_types"]
+    calls = mocks["download"].call_args_list
+    time_slices = calls[0].kwargs["time_slice"]
     assert set(time_slices) == {"historical", "recent", "now"}
 
 
@@ -113,9 +112,8 @@ def test_all_time_slices(tmp_path):
 
 def test_to_parquet_skips_downloads(tmp_path):
     mocks = _run("to-parquet", [], tmp_path)
-    mocks["download_collection"].assert_not_called()
-    mocks["download_metadata"].assert_not_called()
-    mocks["convert_to_parquet"].assert_called()
+    mocks["download"].assert_not_called()
+    mocks["convert"].assert_called()
 
 
 # --- no-parquet ---
@@ -123,29 +121,22 @@ def test_to_parquet_skips_downloads(tmp_path):
 
 def test_no_parquet_skips_conversion(tmp_path):
     mocks = _run("download", ["--no-parquet"], tmp_path)
-    mocks["convert_to_parquet"].assert_not_called()
+    mocks["convert"].assert_not_called()
     mocks["convert_climate_normals_to_parquet"].assert_not_called()
 
 
 def test_default_runs_conversion(tmp_path):
     mocks = _run("download", [], tmp_path)
-    mocks["convert_to_parquet"].assert_called()
+    mocks["convert"].assert_called()
     mocks["convert_climate_normals_to_parquet"].assert_called()
 
 
-def test_default_runs_indoor_handler(tmp_path):
-    """Indoor scenarios (CSV+ZIP) should be downloaded + converted in the default run."""
+def test_default_run_covers_every_tabular_dataset(tmp_path):
+    """Which handler each one needs is the registry's business, not the CLI's."""
     mocks = _run("download", [], tmp_path)
-    mocks["download_climate_scenarios_indoor"].assert_called()
-    mocks["convert_climate_scenarios_indoor_to_parquet"].assert_called()
 
-
-def test_default_runs_climate_scenarios_handler(tmp_path):
-    """climate_scenarios (preamble CSV) should use its bespoke converter, not convert_to_parquet."""
-    mocks = _run("download", [], tmp_path)
-    mocks["convert_climate_scenarios_to_parquet"].assert_called()
-    for call in mocks["convert_to_parquet"].call_args_list:
-        assert call[0][0] != "climate_scenarios"
+    assert _downloaded(mocks) == registry.tabular_datasets()
+    assert _converted(mocks) == registry.tabular_datasets()
 
 
 # --- full-refresh ---
@@ -164,16 +155,14 @@ def test_incremental_passes_since_to_download(tmp_path):
 # --- grids ---
 
 
-def test_grids_flag_enables_grib2_and_netcdf(tmp_path):
+def test_grids_flag_enables_grid_datasets(tmp_path):
     mocks = _run("download", ["--grids"], tmp_path)
-    mocks["download_grib2"].assert_called()
-    mocks["download_netcdf"].assert_called()
+    assert set(_downloaded(mocks)) >= set(registry.grid_datasets())
 
 
 def test_default_skips_grids(tmp_path):
     mocks = _run("download", [], tmp_path)
-    mocks["download_grib2"].assert_not_called()
-    mocks["download_netcdf"].assert_not_called()
+    assert not set(_downloaded(mocks)) & set(registry.grid_datasets())
 
 
 # --- list subcommand ---
@@ -184,7 +173,7 @@ def test_list_prints_collections(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "smn" in out
     assert "Automatic weather stations" in out
-    mocks["download_collection"].assert_not_called()
+    mocks["download"].assert_not_called()
 
 
 # --- env vars ---
@@ -193,18 +182,18 @@ def test_list_prints_collections(tmp_path, capsys):
 def test_env_data_dir_used_when_no_flag(tmp_path, monkeypatch):
     monkeypatch.setenv("FOEHN_DATA_DIR", str(tmp_path / "env-dir"))
     mocks = _run_without_data_dir("download", [], tmp_path)
-    calls = mocks["download_collection"].call_args_list
+    calls = mocks["download"].call_args_list
     assert calls
-    bronze_dir = calls[0][0][1]
+    bronze_dir = calls[0].args[1]
     assert str(tmp_path / "env-dir") in str(bronze_dir)
 
 
 def test_cli_data_dir_overrides_env(tmp_path, monkeypatch):
     monkeypatch.setenv("FOEHN_DATA_DIR", str(tmp_path / "env-dir"))
     mocks = _run("download", [], tmp_path)
-    calls = mocks["download_collection"].call_args_list
+    calls = mocks["download"].call_args_list
     assert calls
-    bronze_dir = calls[0][0][1]
+    bronze_dir = calls[0].args[1]
     assert str(tmp_path) in str(bronze_dir)
     assert "env-dir" not in str(bronze_dir)
 
@@ -267,9 +256,9 @@ def test_incremental_prints_since(tmp_path, capsys):
 
 
 def test_save_last_run_skipped_on_convert_failure(tmp_path, capsys):
-    """If convert_to_parquet reports failures, _last_run.json must NOT be saved."""
+    """If a conversion reports failures, _last_run.json must NOT be saved."""
     mocks, patchers = _start_mocks()
-    mocks["convert_to_parquet"].return_value = 2  # 2 groups failed
+    mocks["convert"].return_value = 2  # 2 groups failed
     try:
         with patch("sys.argv", ["foehn", "download", "--data-dir", str(tmp_path)]), pytest.raises(SystemExit) as exc:
             main()
@@ -284,9 +273,9 @@ def test_save_last_run_skipped_on_convert_failure(tmp_path, capsys):
 
 
 def test_save_last_run_skipped_on_download_failure(tmp_path, capsys):
-    """If download_collection reports failures, _last_run.json must NOT be saved."""
+    """If a download reports failures, _last_run.json must NOT be saved."""
     mocks, patchers = _start_mocks()
-    mocks["download_collection"].return_value.failed = 1
+    mocks["download"].return_value.failed = 1
     try:
         with patch("sys.argv", ["foehn", "download", "--data-dir", str(tmp_path)]), pytest.raises(SystemExit) as exc:
             main()
@@ -308,7 +297,7 @@ def test_save_last_run_called_on_clean_run(tmp_path):
 
 def test_to_parquet_exits_nonzero_on_failure(tmp_path):
     mocks, patchers = _start_mocks()
-    mocks["convert_to_parquet"].return_value = 1
+    mocks["convert"].return_value = 1
     try:
         with patch("sys.argv", ["foehn", "to-parquet", "--data-dir", str(tmp_path)]), pytest.raises(SystemExit) as exc:
             main()
@@ -323,13 +312,7 @@ def test_to_parquet_exits_nonzero_on_failure(tmp_path):
 
 def test_to_parquet_skips_grid_collections(tmp_path):
     mocks = _run("to-parquet", [], tmp_path)
-    # convert_to_parquet should only be called for CSV collections, not grid ones
-    for call in mocks["convert_to_parquet"].call_args_list:
-        key = call[0][0]
-        from foehn.collections import GRIB2_COLLECTIONS, NETCDF_COLLECTIONS
-
-        assert key not in GRIB2_COLLECTIONS
-        assert key not in NETCDF_COLLECTIONS
+    assert all(registry.spec(key).tabular for key in _converted(mocks))
 
 
 # --- load subcommand ---

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,11 +4,8 @@ from foehn.api import list_datasets
 from foehn.collections import (
     COLLECTION_META,
     COLLECTIONS,
-    CSV_ZIP_COLLECTIONS,
-    FORECAST_CSV_COLLECTIONS,
-    GRIB2_COLLECTIONS,
-    NETCDF_COLLECTIONS,
-    PREAMBLE_CSV_COLLECTIONS,
+    KIND_OF,
+    DatasetKind,
     forecast_run_from_filename,
     time_slice_from_filename,
 )
@@ -55,39 +52,35 @@ def test_collections_keys_are_strings():
         assert isinstance(collection_id, str) and collection_id.startswith("ch.")
 
 
-def test_routing_sets_are_subsets_of_collections():
-    keys = set(COLLECTIONS.keys())
-    assert keys >= FORECAST_CSV_COLLECTIONS
-    assert keys >= GRIB2_COLLECTIONS
-    assert keys >= NETCDF_COLLECTIONS
-    assert keys >= CSV_ZIP_COLLECTIONS
-    assert keys >= PREAMBLE_CSV_COLLECTIONS
+def test_every_collection_has_exactly_one_kind():
+    """The old routing sets could disagree; one mapping cannot.
+
+    They also had to be kept mutually exclusive by hand — a collection in two
+    sets routed differently depending on which ladder reached it first.
+    """
+    assert set(KIND_OF) == set(COLLECTIONS)
+    assert all(isinstance(k, DatasetKind) for k in KIND_OF.values())
 
 
-def test_routing_sets_are_mutually_exclusive():
-    """A collection should belong to at most one routing set."""
-    all_sets = [
-        FORECAST_CSV_COLLECTIONS,
-        GRIB2_COLLECTIONS,
-        NETCDF_COLLECTIONS,
-        CSV_ZIP_COLLECTIONS,
-        PREAMBLE_CSV_COLLECTIONS,
-    ]
-    for i, a in enumerate(all_sets):
-        for b in all_sets[i + 1 :]:
-            assert a.isdisjoint(b), f"Overlap between routing sets: {a & b}"
+def test_every_kind_is_used():
+    """A kind nothing maps to is a branch no caller can reach."""
+    assert set(KIND_OF.values()) == set(DatasetKind)
 
 
-def test_indoor_scenarios_is_csv_zip_not_netcdf():
-    assert "climate_scenarios_indoor" in CSV_ZIP_COLLECTIONS
-    assert "climate_scenarios_indoor" not in NETCDF_COLLECTIONS
-    assert COLLECTION_META["climate_scenarios_indoor"]["format"] == "CSV+ZIP"
+def test_indoor_scenarios_is_an_archive_of_csvs():
+    """The archive-ness is the kind; the format is plain CSV, which is what it is."""
+    assert KIND_OF["climate_scenarios_indoor"] is DatasetKind.ARCHIVE_CSV
+    assert COLLECTION_META["climate_scenarios_indoor"]["format"] == "CSV"
 
 
 def test_climate_scenarios_is_preamble_csv():
-    assert "climate_scenarios" in PREAMBLE_CSV_COLLECTIONS
-    assert "climate_scenarios" not in NETCDF_COLLECTIONS
-    assert "climate_scenarios" not in CSV_ZIP_COLLECTIONS
+    assert KIND_OF["climate_scenarios"] is DatasetKind.PREAMBLE_CSV
+
+
+def test_radar_is_its_own_kind_not_grib2():
+    """GRIB2_COLLECTIONS used to hold the HDF5 radar datasets; the name lied."""
+    assert KIND_OF["radar_precip"] is DatasetKind.RADAR_GRID
+    assert COLLECTION_META["radar_precip"]["format"] == "HDF5"
 
 
 def test_collection_ids_are_unique():
@@ -155,7 +148,7 @@ def test_spatial_climate_analysis_grids_are_netcdf():
     # static NetCDF collections, read via open_dataset/to_zarr like the others.
     for key in ("radar_derived_grid", "climate_normals_grid"):
         assert COLLECTION_META[key]["format"] == "NetCDF"
-        assert key in NETCDF_COLLECTIONS
+        assert KIND_OF[key] is DatasetKind.NETCDF_GRID
 
 
 # --- forecast run timestamps ---

--- a/tests/test_ingest_delta.py
+++ b/tests/test_ingest_delta.py
@@ -327,11 +327,13 @@ def test_ingest_climate_normals_empty_dir(tmp_path, mock_spark):
 
 
 def test_tabular_collections_excludes_binary():
-    from foehn.collections import GRIB2_COLLECTIONS, NETCDF_COLLECTIONS
+    from foehn import registry
 
     for key in TABULAR_COLLECTIONS:
-        assert key not in GRIB2_COLLECTIONS
-        assert key not in NETCDF_COLLECTIONS
+        # climate_normals is a ZIP from opendata.swiss, not a STAC collection,
+        # so it has no kind — everything else must be a tabular one.
+        if key != "climate_normals":
+            assert registry.spec(key).tabular
 
 
 def test_tabular_collections_includes_climate_normals():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,7 +10,8 @@ import pytest
 
 pytest.importorskip("mcp", reason="mcp not installed")
 
-from foehn.collections import COLLECTIONS, GRIB2_COLLECTIONS, NETCDF_COLLECTIONS
+from foehn import registry
+from foehn.collections import COLLECTIONS
 from foehn.mcp_server import (
     _INSPECTABLE_GRIDS,
     _LOADABLE_DATASETS,
@@ -40,11 +41,11 @@ from foehn.mcp_server import (
 
 class TestConstants:
     def test_loadable_datasets_excludes_grib2(self):
-        for ds in GRIB2_COLLECTIONS:
+        for ds in registry.grid_datasets():
             assert ds not in _LOADABLE_DATASETS
 
     def test_loadable_datasets_excludes_netcdf(self):
-        for ds in NETCDF_COLLECTIONS:
+        for ds in registry.grid_datasets():
             assert ds not in _LOADABLE_DATASETS
 
     def test_loadable_datasets_is_sorted(self):
@@ -55,7 +56,7 @@ class TestConstants:
             assert ds in COLLECTIONS
 
     def test_inspectable_grids_are_all_gridded(self):
-        assert sorted(NETCDF_COLLECTIONS | GRIB2_COLLECTIONS) == _INSPECTABLE_GRIDS
+        assert sorted(registry.grid_datasets()) == _INSPECTABLE_GRIDS
 
     def test_valid_frequencies(self):
         assert {"t", "h", "d", "m", "y"} == _VALID_FREQUENCIES
@@ -697,7 +698,7 @@ class TestUsageGuide:
 
     def test_contains_binary_datasets(self):
         result = usage_guide()
-        for ds in sorted(GRIB2_COLLECTIONS | NETCDF_COLLECTIONS):
+        for ds in sorted(registry.grid_datasets()):
             assert f"`{ds}`" in result
 
     def test_contains_workflow_steps(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,172 @@
+"""Tests for the dataset-kind registry.
+
+This is where the routing lives now, so this is where it is tested. The
+equivalents used to be spread across test_api and test_cli as "does download()
+call the grib2 handler?" — one assertion per caller per kind, which is the
+duplication the registry removes.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from foehn import registry
+from foehn.client import DownloadResult
+from foehn.collections import COLLECTIONS, KIND_OF, DatasetKind
+
+
+def test_every_kind_has_a_spec():
+    """A kind with no spec is a dataset that cannot be routed at all."""
+    assert set(registry.KINDS) == set(DatasetKind)
+
+
+def test_every_dataset_resolves_to_a_spec():
+    for dataset in COLLECTIONS:
+        assert isinstance(registry.spec(dataset), registry.KindSpec)
+
+
+def test_unknown_dataset_raises():
+    with pytest.raises(KeyError):
+        registry.spec("nonexistent")
+
+
+# --- what each kind can do ---
+
+
+@pytest.mark.parametrize(
+    ("dataset", "expected"),
+    [
+        ("smn", DatasetKind.STANDARD_CSV),
+        ("climate_scenarios", DatasetKind.PREAMBLE_CSV),
+        ("climate_scenarios_indoor", DatasetKind.ARCHIVE_CSV),
+        ("forecast_local", DatasetKind.FORECAST_CSV),
+        ("surface_derived_grid", DatasetKind.NETCDF_GRID),
+        ("forecast_icon_ch1", DatasetKind.GRIB2_GRID),
+        ("radar_precip", DatasetKind.RADAR_GRID),
+    ],
+)
+def test_representative_datasets_map_to_their_kind(dataset, expected):
+    assert KIND_OF[dataset] is expected
+
+
+def test_grid_kinds_have_no_parquet_path():
+    """Not a branch every caller re-derives — a fact the kind carries."""
+    for kind_ in (DatasetKind.NETCDF_GRID, DatasetKind.GRIB2_GRID, DatasetKind.RADAR_GRID):
+        assert registry.KINDS[kind_].convert is None
+        assert registry.KINDS[kind_].tabular is False
+
+
+def test_tabular_kinds_all_convert():
+    for kind_, spec in registry.KINDS.items():
+        if spec.tabular:
+            assert spec.convert is not None, f"{kind_} is tabular but has no converter"
+
+
+def test_only_standard_csv_supports_granularity():
+    """The other CSV kinds' filenames carry no granularity segment to filter on."""
+    supported = {k for k, spec in registry.KINDS.items() if spec.supports_granularity}
+    assert supported == {DatasetKind.STANDARD_CSV}
+
+
+def test_preamble_csv_rejects_calendar_filters():
+    """Its dates are nominal (0001..0030), so a calendar filter matches nothing."""
+    assert registry.KINDS[DatasetKind.PREAMBLE_CSV].supports_calendar_filters is False
+    assert registry.KINDS[DatasetKind.STANDARD_CSV].supports_calendar_filters is True
+
+
+def test_key_columns_differ_where_the_schema_does():
+    """``columns=`` keeps a different set per kind; it used to be passed in by hand."""
+    assert registry.KINDS[DatasetKind.PREAMBLE_CSV].key_columns == ("station_abbr", "variable", "gwl", "date")
+    assert "period" in registry.KINDS[DatasetKind.ARCHIVE_CSV].key_columns
+    assert registry.KINDS[DatasetKind.STANDARD_CSV].key_columns == ("station_abbr", "reference_timestamp")
+
+
+# --- dataset listings ---
+
+
+def test_tabular_and_grid_datasets_partition_the_collections():
+    assert set(registry.tabular_datasets()) | set(registry.grid_datasets()) == set(COLLECTIONS)
+    assert not set(registry.tabular_datasets()) & set(registry.grid_datasets())
+
+
+def test_listings_keep_declaration_order():
+    """Order is what the CLI prints and what the MCP tool advertises."""
+    assert registry.tabular_datasets() == [k for k in COLLECTIONS if k in registry.tabular_datasets()]
+
+
+# --- dispatch ---
+
+
+@pytest.mark.parametrize(
+    ("dataset", "handler"),
+    [
+        ("smn", "download_collection"),
+        ("forecast_local", "download_collection"),
+        ("climate_scenarios", "download_collection"),
+        ("climate_scenarios_indoor", "download_climate_scenarios_indoor"),
+        ("forecast_icon_ch1", "download_grib2"),
+        ("radar_precip", "download_grib2"),
+        ("surface_derived_grid", "download_netcdf"),
+    ],
+)
+def test_download_reaches_the_right_handler(dataset, handler, tmp_path):
+    with patch(f"foehn.registry.{handler}") as mock, patch("foehn.registry.download_metadata") as mock_meta:
+        mock.return_value = DownloadResult()
+        mock_meta.return_value = DownloadResult()
+        registry.download(dataset, tmp_path, fetcher=object())
+    assert mock.called
+
+
+def test_standard_download_sums_metadata_and_collection(tmp_path):
+    """Both callers used to do this pairing themselves, and counted it differently."""
+    with (
+        patch("foehn.registry.download_metadata") as mock_meta,
+        patch("foehn.registry.download_collection") as mock_coll,
+    ):
+        mock_meta.return_value = DownloadResult(total_assets=1, downloaded=1, filenames=["m.csv"])
+        mock_coll.return_value = DownloadResult(total_assets=2, downloaded=2, failed=1, filenames=["a.csv", "b.csv"])
+
+        result = registry.download("smn", tmp_path, fetcher=object())
+
+    assert result.total_assets == 3
+    assert result.downloaded == 3
+    assert result.failed == 1
+    assert result.filenames == ["m.csv", "a.csv", "b.csv"]
+
+
+def test_download_defaults_to_the_recent_slice(tmp_path):
+    with patch("foehn.registry.download_collection") as mock_coll, patch("foehn.registry.download_metadata") as m:
+        mock_coll.return_value = m.return_value = DownloadResult()
+        registry.download("smn", tmp_path, fetcher=object())
+    assert mock_coll.call_args.kwargs["data_types"] == ["recent"]
+
+
+@pytest.mark.parametrize(
+    ("dataset", "converter"),
+    [
+        ("smn", "convert_to_parquet"),
+        ("forecast_local", "convert_to_parquet"),
+        ("climate_scenarios", "convert_climate_scenarios_to_parquet"),
+        ("climate_scenarios_indoor", "convert_climate_scenarios_indoor_to_parquet"),
+    ],
+)
+def test_convert_reaches_the_right_converter(dataset, converter, tmp_path):
+    with patch(f"foehn.registry.{converter}") as mock:
+        mock.return_value = 0
+        registry.convert(dataset, tmp_path / "bronze", tmp_path / "parquet")
+    assert mock.called
+
+
+@pytest.mark.parametrize("dataset", ["surface_derived_grid", "forecast_icon_ch1", "radar_precip"])
+def test_convert_is_a_no_op_for_grids(dataset, tmp_path):
+    """Callers used to `continue` past these; now there is nothing to skip."""
+    assert registry.convert(dataset, tmp_path / "bronze", tmp_path / "parquet") == 0
+
+
+def test_convert_passes_the_directories_through(tmp_path):
+    with patch("foehn.registry.convert_to_parquet") as mock:
+        mock.return_value = 3
+        failures = registry.convert("smn", Path("bronze"), Path("parquet"))
+    mock.assert_called_once_with("smn", Path("bronze"), Path("parquet"))
+    assert failures == 3


### PR DESCRIPTION
Second of the two architecture PRs. Depends on #48, which landed first so these call sites had a test surface that survives moving code between modules.

## Why

Six frozensets in `collections.py` encoded what kind of dataset a key was, and **six if/elif ladders** re-derived the download/convert routing from them — in `api.download`, `api.to_parquet`, `api.load`, `cli.cmd_download`, `cli.cmd_to_parquet` and `ingest_delta.TABULAR_COLLECTIONS`, plus guards in `mcp_server`. **45 membership tests** outside `collections.py`. Adding a collection meant editing all of them, and the sets had to be kept mutually exclusive by hand — one in two sets routed differently depending on which ladder reached it first.

## What

`DatasetKind` (seven values) and `KIND_OF` in `collections.py` — the leaf module that already holds every other dataset fact, so `grids` can key on it without a cycle. `registry.py` holds the table: each kind's download adapter, convert adapter, and the filters it supports.

```
DatasetKind      STANDARD_CSV · PREAMBLE_CSV · ARCHIVE_CSV · FORECAST_CSV
                 NETCDF_GRID · GRIB2_GRID · RADAR_GRID
KindSpec         download · convert · tabular · supports_granularity
                 supports_calendar_filters · key_columns
```

All six ladders are gone. So are all six frozensets — `NO_GRANULARITY_COLLECTIONS` was derivable from the kind and disappears for free.

**One deviation from the plan, worth review.** The registry holds download and convert adapters but *not* a load callable: the load readers (`_load_indoor`, `_load_climate_scenarios`) are `api`-private, and hoisting them into the registry to fill a column would invert the dependency. What the registry says about loading is which filters a kind supports — and `load()`'s hand-written rejection rules are now generated from that rather than typed out per dataset.

## Also

- **`climate_scenarios_indoor`'s format is now `CSV`, not `CSV+ZIP`.** The archive-ness is the kind; format says what the bytes are. This is a breaking change to `list_datasets()` output and one MCP response — and it fixes a live wart: `foehn list --format CSV` never listed it.
- **`_GRID_READERS` keys on `DatasetKind`**, removing the last format-based routing and letting the comment apologising for `GRIB2_COLLECTIONS` holding the HDF5 radar datasets be deleted. `fmt` survives only where it is shown to users in error messages.
- **Routing tests moved** from `test_api`/`test_cli` to a new `test_registry.py`, where the routing now lives. The CLI tests stub `registry.download`/`registry.convert` instead of ten individual handlers.

## Verification

- 426 tests pass (up from 392); coverage 90.3%, `registry.py` at 100%
- `ty check src/` and `ruff` clean
- Both live tests pass
- Smoke-tested against the live API: `load()`, the three rejection guards (nominal dates, granularity, grid), and `foehn list --format CSV` now including the indoor scenarios