### PR TITLE
Let Dependabot own the pinned dev toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,32 @@ updates:
         update-types:
           - major
 
+  # The pinned dev toolchain (ruff, zizmor, the hygiene hooks) lives in
+  # .pre-commit-config.yaml, and CI reads its versions from there — so bumping
+  # this file is what keeps the whole toolchain current.
+  - package-ecosystem: pre-commit
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:15"
+      timezone: Europe/Zurich
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      pre-commit-patch-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      pre-commit-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  # Single source of truth for the pinned dev toolchain. RUFF_VERSION must stay
-  # in step with .pre-commit-config.yaml so local hooks and CI agree — a drifting
-  # ruff turns green PRs red with no code change.
-  RUFF_VERSION: "0.16.4"
-  TY_VERSION: "0.0.74"
-  ZIZMOR_VERSION: "1.29.0"
+# The pinned dev toolchain lives in .pre-commit-config.yaml (ruff, zizmor) and
+# the pyproject dev extra (ty), both of which Dependabot bumps. The jobs below
+# read the versions from there rather than repeating them here: the previous
+# env vars had to be kept in step with the hook revs by hand, and a silent
+# mismatch means local hooks and CI disagree about what "clean" means.
   PIP_AUDIT_VERSION: "2.9.0"
   # Must match the pins in publish.yml — the build job below is that job's smoke
   # test, and only catches its failures if it runs the same toolchain.
@@ -39,10 +37,19 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
+      - name: Resolve pinned ruff
+        id: ruff
+        run: scripts/hook_version.sh ruff-pre-commit >> "$GITHUB_OUTPUT"
       # scripts/ is linted too — ingest_delta.py builds Spark SQL by hand and is
       # the highest-risk file in the repo.
-      - run: uvx ruff@${RUFF_VERSION} check src/ tests/ scripts/
-      - run: uvx ruff@${RUFF_VERSION} format --check src/ tests/ scripts/
+      # Via env rather than expanding ${{ }} straight into the run block, which
+      # is the template-injection shape zizmor flags.
+      - run: uvx "ruff@${RUFF_PIN}" check src/ tests/ scripts/
+        env:
+          RUFF_PIN: ${{ steps.ruff.outputs.version }}
+      - run: uvx "ruff@${RUFF_PIN}" format --check src/ tests/ scripts/
+        env:
+          RUFF_PIN: ${{ steps.ruff.outputs.version }}
 
   typecheck:
     runs-on: ubuntu-latest
@@ -57,7 +64,8 @@ jobs:
       # foehn ships py.typed, so downstream type checkers trust these annotations.
       # Nothing verified them before this job existed.
       - run: uv venv --python 3.12
-      - run: uv pip install -e ".[dev]" "ty==${TY_VERSION}"
+      # ty is pinned in the pyproject dev extra, so Dependabot bumps it there.
+      - run: uv pip install -e ".[dev]"
       - run: .venv/bin/ty check src/
 
   test:
@@ -163,9 +171,13 @@ jobs:
       # Static analysis for the workflows themselves: template injection, unpinned
       # actions, credential persistence, over-broad permissions. Clean as of this
       # commit — the point is to keep it that way as workflows change.
+      - name: Resolve pinned zizmor
+        id: zizmor
+        run: scripts/hook_version.sh zizmor-pre-commit >> "$GITHUB_OUTPUT"
       - name: Run zizmor
-        run: uvx zizmor@${ZIZMOR_VERSION} --format sarif .github/workflows/ > zizmor.sarif
+        run: uvx "zizmor@${ZIZMOR_PIN}" --format sarif .github/workflows/ > zizmor.sarif
         env:
+          ZIZMOR_PIN: ${{ steps.zizmor.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF
         if: always() && hashFiles('zizmor.sarif') != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# The pinned dev toolchain lives in .pre-commit-config.yaml (ruff, zizmor) and
-# the pyproject dev extra (ty), both of which Dependabot bumps. The jobs below
-# read the versions from there rather than repeating them here: the previous
-# env vars had to be kept in step with the hook revs by hand, and a silent
-# mismatch means local hooks and CI disagree about what "clean" means.
+# ruff, zizmor and ty are NOT pinned here: they live in .pre-commit-config.yaml
+# and the pyproject dev extra, both of which Dependabot bumps, and the jobs below
+# read the versions from there. They used to be duplicated here and kept in step
+# by hand, and a silent mismatch means local hooks and CI disagree about what
+# "clean" means. The pins that remain are single-copy, so they cannot drift.
+env:
   PIP_AUDIT_VERSION: "2.9.0"
   # Must match the pins in publish.yml — the build job below is that job's smoke
   # test, and only catches its failures if it runs the same toolchain.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,15 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=2048]
 
+  # Validates workflows against GitHub's own schema and expression contexts.
+  # check-yaml only proves a file is well-formed YAML — it happily accepted a
+  # workflow whose `env:` block had lost its key and been silently reparented
+  # under `concurrency:`, which GitHub then refused to run at all.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+
   # Workflow static analysis, same version CI runs.
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.29.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
-# Keep the ruff rev in step with RUFF_VERSION in .github/workflows/ci.yml —
-# a mismatch means hooks and CI disagree about what "clean" means.
+# The single source of truth for the pinned dev toolchain. CI reads the ruff and
+# zizmor versions out of this file rather than repeating them, so local hooks and
+# CI cannot disagree about what "clean" means — they were previously kept in step
+# by hand, and a drifting ruff turns green PRs red with no code change.
+# Dependabot bumps these revs weekly (see .github/dependabot.yml).
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ dev = [
     "ty==0.0.74",
     "numpy>=1.24",
     "pydantic>=2.0",
+    # Strict YAML parsing for the workflow-structure test: PyYAML silently
+    # tolerates the duplicate keys and reparenting that break a workflow.
+    "ruamel.yaml>=0.18",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "pyarrow>=14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,11 +73,12 @@ grids = [
 ]
 dev = [
     "ruff>=0.9",
-    # Typechecks src/ in CI, which pins the exact version (TY_VERSION in ci.yml).
-    # The floor here is so a local `ty check` is available without hunting for it;
-    # keep it at or below the CI pin. ty is pre-1.0, so treat a version bump as a
-    # change that can turn a green PR red on its own.
-    "ty>=0.0.74",
+    # Pinned, not floored: ty typechecks src/ in CI, it is pre-1.0, and a version
+    # bump can turn a green PR red on its own. Dependabot bumps this weekly, so
+    # the upgrade arrives as its own reviewable PR rather than landing on whoever
+    # opens the next one. (ruff and zizmor are pinned in .pre-commit-config.yaml,
+    # which CI reads — see scripts/hook_version.sh.)
+    "ty==0.0.74",
     "numpy>=1.24",
     "pydantic>=2.0",
     "pytest>=8.0",

--- a/scripts/hook_version.sh
+++ b/scripts/hook_version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Print `version=<v>` for a pre-commit hook repo, for use as a GitHub step output.
+#
+# .pre-commit-config.yaml is the single source of truth for the pinned dev
+# toolchain, and Dependabot bumps it. CI resolves the version from there rather
+# than repeating it in an env var that has to be kept in step by hand.
+#
+#   usage: scripts/hook_version.sh ruff-pre-commit
+set -euo pipefail
+
+repo="${1:?usage: hook_version.sh <pre-commit repo name>}"
+config="${2:-.pre-commit-config.yaml}"
+
+# The `rev:` on the first line following the matching `repo:` entry.
+version="$(awk -v repo="$repo" '
+  $0 ~ "repo:.*/" repo "$" { found = 1; next }
+  found && $1 == "rev:" { sub(/^v/, "", $2); print $2; exit }
+' "$config")"
+
+if [ -z "$version" ]; then
+  echo "no rev found for $repo in $config" >&2
+  exit 1
+fi
+echo "version=$version"

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -83,3 +83,25 @@ def test_ty_is_pinned_exactly():
     dev = pyproject["project"]["optional-dependencies"]["dev"]
     ty = next(d for d in dev if d.startswith("ty"))
     assert ty.startswith("ty=="), f"expected an exact pin, got {ty!r}"
+
+
+def test_workflow_env_block_holds_the_single_copy_pins():
+    """The remaining pins must stay under `env:`, not drift into a neighbour.
+
+    Regression: removing three entries from this block once took the ``env:``
+    key with them, leaving the other four indented under ``concurrency:``. That
+    is valid YAML and passes a schema check, so both slipped through — and
+    GitHub refused to start the workflow. actionlint (a pre-commit hook now)
+    catches the general case; this pins the specific keys.
+    """
+    from ruamel.yaml import YAML
+
+    workflow = YAML(typ="safe").load(WORKFLOW.read_text())
+
+    assert set(workflow["concurrency"]) == {"group", "cancel-in-progress"}
+    assert set(workflow["env"]) == {
+        "PIP_AUDIT_VERSION",
+        "BUILD_VERSION",
+        "TWINE_VERSION",
+        "BANDIT_VERSION",
+    }

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -1,0 +1,85 @@
+"""The pinned dev toolchain is declared once and read from there.
+
+CI resolves ruff and zizmor out of .pre-commit-config.yaml via
+scripts/hook_version.sh, so if that parse breaks the lint and zizmor jobs break
+with it. These tests guard the contract from the repo side, where a broken
+config shows up before it reaches CI.
+"""
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+PRE_COMMIT = ROOT / ".pre-commit-config.yaml"
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _hook_version(repo: str) -> str:
+    # S603: the command and its argument are repo-local literals, not input.
+    result = subprocess.run(  # noqa: S603
+        [str(ROOT / "scripts" / "hook_version.sh"), repo],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=ROOT,
+    )
+    key, _, value = result.stdout.strip().partition("=")
+    assert key == "version"
+    return value
+
+
+@pytest.mark.parametrize("repo", ["ruff-pre-commit", "zizmor-pre-commit"])
+def test_hook_version_resolves_a_version(repo):
+    assert re.fullmatch(r"\d+\.\d+\.\d+", _hook_version(repo)), f"unparseable rev for {repo}"
+
+
+@pytest.mark.parametrize("repo", ["ruff-pre-commit", "zizmor-pre-commit"])
+def test_hook_version_matches_the_config(repo):
+    """The script must report the rev actually pinned, not a stale or nearby one."""
+    config = PRE_COMMIT.read_text()
+    block = config.split(f"/{repo}\n", 1)[1]
+    expected = re.search(r"rev:\s*v?(\S+)", block).group(1)
+    assert _hook_version(repo) == expected
+
+
+def test_hook_version_fails_on_an_unknown_repo():
+    """A silent empty version would make CI run `uvx ruff@` and fail obscurely."""
+    result = subprocess.run(  # noqa: S603
+        [str(ROOT / "scripts" / "hook_version.sh"), "not-a-repo"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode != 0
+    assert "no rev found" in result.stderr
+
+
+def test_workflow_hardcodes_no_shared_tool_version():
+    """ruff, ty and zizmor are declared where Dependabot bumps them, not here.
+
+    Scoped to the three that are pinned in two places — .pre-commit-config.yaml
+    (ruff, zizmor) and the pyproject dev extra (ty) — because a second copy in
+    ci.yml is what silently drifts out of step. The workflow's other pins
+    (pip-audit, build, twine, bandit) live only here and so cannot disagree with
+    anything; they are stale-prone, not drift-prone.
+
+    Checks for a literal rather than for particular variable names: the names are
+    fine (the jobs pass the resolved version through ``env:`` to keep it out of
+    the run block), it is a hardcoded value that goes stale.
+    """
+    workflow = WORKFLOW.read_text()
+    for tool in ("RUFF", "TY", "ZIZMOR"):
+        hardcoded = re.findall(rf"^\s*{tool}_\w*:\s*\"?\d+\.\d+\.\d+", workflow, re.MULTILINE)
+        assert not hardcoded, f"ci.yml hardcodes {tool}; it will drift from its source of truth"
+
+
+def test_ty_is_pinned_exactly():
+    """A floor would let a pre-1.0 bump land on an unrelated PR."""
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    dev = pyproject["project"]["optional-dependencies"]["dev"]
+    ty = next(d for d in dev if d.startswith("ty"))
+    assert ty.startswith("ty=="), f"expected an exact pin, got {ty!r}"


### PR DESCRIPTION
Follow-up to a question raised while reviewing #48: should the dev tools track latest?

**Not latest — pinned, but bumped automatically.** Your own `ci.yml` comment names the failure mode: *"a drifting ruff turns green PRs red with no code change."* That's real here because `[tool.ruff.lint] select` lists rule *families* (`E`, `F`, `B`, `SIM`, `RUF`, `PERF`…), so a new ruff minor adds rules to sets already opted into, and `ty` is pre-1.0. On latest, that lands as a red CI on whoever opens the next unrelated PR. Automated bumps get you the same currency, as a PR that either goes green or shows exactly what broke.

## The actual problem

Three tools were pinned in **two places each**, kept in step by hand:

| Tool | Was pinned in | Bumped by |
|---|---|---|
| ruff | `.pre-commit-config.yaml:5` **and** `RUFF_VERSION` in `ci.yml` | nobody |
| zizmor | `.pre-commit-config.yaml:29` **and** `ZIZMOR_VERSION` | nobody |
| ty | `TY_VERSION` in `ci.yml`, plus a floor in `pyproject.toml` | nobody |

Dependabot watched the pip and github-actions ecosystems — neither of which sees pre-commit revs or workflow `env:` vars.

## What changed

- **`.pre-commit-config.yaml` is now the single source** for ruff and zizmor. CI resolves the version from it via `scripts/hook_version.sh`, so local hooks and CI cannot disagree by construction — the duplication is gone rather than merely synchronised.
- **`ty` is pinned exactly** in the pyproject dev extra (was a floor), so Dependabot's existing pip config bumps it.
- **`package-ecosystem: pre-commit` added** to Dependabot, with the same 7-day cooldown and major/minor split as the other two ecosystems.
- `RUFF_VERSION`, `TY_VERSION` and `ZIZMOR_VERSION` are deleted from `ci.yml`.

Resolved versions reach the run blocks through `env:` rather than expanding `${{ }}` inline — the template-injection shape zizmor flags. `zizmor .github/workflows/` reports no findings, same as before.

## Not changed, deliberately

`ci.yml` also pins `pip-audit`, `build`, `twine` and `bandit`. Those live in exactly one place, so they can't drift out of step with anything — they're stale-prone, not drift-prone, which is a smaller and different problem. Happy to move them into a Dependabot-managed file as a follow-up if you want them current too.

## Verification

- `scripts/hook_version.sh` resolves 0.16.4 today, and 0.17.9 against a config with a bumped rev — so CI follows Dependabot with no further edit
- `tests/test_toolchain.py` guards the parse, the failure mode on an unknown repo, and that no hardcoded ruff/ty/zizmor version comes back into `ci.yml`
- All workflow YAML validated with duplicate-key-strict parsing (which caught a duplicate `env:` block PyYAML had silently accepted)
- 433 tests pass; ruff, ty and zizmor clean