### PR TITLE
Clear the small review findings

### DIFF
--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -296,6 +296,7 @@ def _apply_time_filters(
 
 def _apply_post_filters(
     df: pl.DataFrame,
+    dataset: str,
     *,
     year: int | list[int] | None = None,
     month: int | list[int] | None = None,
@@ -305,19 +306,24 @@ def _apply_post_filters(
     sort: str | None = None,
     columns: list[str] | None = None,
     limit: int | None = None,
-    keep_cols: tuple[str, ...] = ("station_abbr", "reference_timestamp"),
 ) -> pl.DataFrame:
-    """Apply the shared in-memory row/column filters used by load() variants."""
-    ts = "reference_timestamp"
+    """Apply the shared in-memory row/column filters used by load() variants.
+
+    Which columns an explicit ``columns=`` selection always keeps is a property of
+    the dataset's kind, so it is read from the registry rather than passed in —
+    callers were previously stating their own schema across this seam, and only
+    one of the three got it right for its kind.
+    """
+    spec = registry.spec(dataset)
     df = _apply_time_filters(df, year=year, month=month, date_from=date_from, date_to=date_to)
     if drop_null:
         _require_columns(df, [drop_null], "drop_null")
         df = df.filter(pl.col(drop_null).is_not_null())
     if sort in ("asc", "desc"):
-        df = df.sort(ts, descending=(sort == "desc"))
+        df = df.sort(spec.sort_column, descending=(sort == "desc"))
     if columns:
         _require_columns(df, columns, "columns")
-        keep = [c for c in keep_cols if c in df.columns]
+        keep = [c for c in spec.key_columns if c in df.columns]
         keep += [c for c in columns if c not in keep]
         df = df.select(keep)
     if limit is not None:
@@ -391,6 +397,7 @@ def _load_indoor(
     df = pl.concat(frames, how="diagonal_relaxed")
     return _apply_post_filters(
         df,
+        dataset,
         year=year,
         month=month,
         date_from=date_from,
@@ -399,7 +406,6 @@ def _load_indoor(
         sort=sort,
         columns=columns,
         limit=limit,
-        keep_cols=("station_abbr", "reference_timestamp", "period", "scenario", "variant"),
     )
 
 
@@ -453,20 +459,10 @@ def _load_climate_scenarios(
             frames = list(pool.map(_fetch, hrefs))
 
     df = pl.concat(frames, how="diagonal_relaxed")
-
-    if drop_null:
-        _require_columns(df, [drop_null], "drop_null")
-        df = df.filter(pl.col(drop_null).is_not_null())
-    if sort in ("asc", "desc"):
-        df = df.sort("date", descending=(sort == "desc"))
-    if columns:
-        _require_columns(df, columns, "columns")
-        keep = [c for c in ("station_abbr", "variable", "gwl", "date") if c in df.columns]
-        keep += [c for c in columns if c not in keep]
-        df = df.select(keep)
-    if limit is not None:
-        df = df.head(limit)
-    return df
+    # The calendar filters are rejected for this kind before we get here, so the
+    # shared pass's time filtering is a no-op and only the column/sort/limit half
+    # applies — which is why this can use it rather than repeating it.
+    return _apply_post_filters(df, dataset, drop_null=drop_null, sort=sort, columns=columns, limit=limit)
 
 
 def load(
@@ -586,9 +582,11 @@ def load(
     elif isinstance(time_slice, str):
         time_slice = [time_slice]
 
-    # Normalise station filter to a set of lowercase abbreviations.
+    # Normalise station filter to a set of lowercase abbreviations. An empty list
+    # means "no filter", not "match nothing" — the latter is never what a caller
+    # wants, and the MCP layer used to strip empty lists on load()'s behalf.
     station_filter: set[str] | None = None
-    if station is not None:
+    if station:
         if isinstance(station, str):
             station_filter = {station.lower()}
         else:
@@ -596,7 +594,7 @@ def load(
 
     # Normalise frequency filter to a set (e.g. {"d", "h"}).
     freq_filter: set[str] | None = None
-    if frequency is not None:
+    if frequency:
         if isinstance(frequency, str):
             freq_filter = {frequency.lower()}
         else:
@@ -707,6 +705,7 @@ def load(
 
     return _apply_post_filters(
         df,
+        dataset,
         year=year,
         month=month,
         date_from=date_from,

--- a/src/foehn/cli.py
+++ b/src/foehn/cli.py
@@ -216,20 +216,23 @@ def cmd_metadata(args: argparse.Namespace) -> None:
 
     # Table output similar to foehn list
     headers = df.columns
-    # Compute column widths (min width = header length, capped at 40). Measured in
-    # Polars rather than by materialising every column as a Python list of strings —
-    # that pass ran over the whole frame before iter_rows() walked it a second time,
-    # which is seconds of pure-Python work on a large inventory.
-    max_lens = df.select(pl.col(c).cast(pl.Utf8).str.len_chars().max().alias(c) for c in headers).row(0)
+    # Render to strings once, in Polars, and measure and print from that same
+    # projection. Measuring in Polars while printing Python's str() looked
+    # equivalent but is not: a Datetime casts to 26 characters here
+    # ("...00:00:00.000000") against str()'s 19, so the column came out padded
+    # wider than anything in it. Doing both from one projection cannot drift —
+    # and it keeps the measurement off the pure-Python path, which took seconds
+    # on a large inventory.
+    rendered = df.select(pl.col(c).cast(pl.Utf8).fill_null("—").alias(c) for c in headers)
+    max_lens = rendered.select(pl.col(c).str.len_chars().max().alias(c) for c in headers).row(0)
     widths = [min(max(len(col), n or 0), 40) for col, n in zip(headers, max_lens, strict=True)]
 
     fmt = "  ".join(f"{{:<{w}}}" for w in widths)
     print(fmt.format(*headers))
     print(fmt.format(*(("─" * w) for w in widths)))
-    for row in df.iter_rows():
-        values = [str(v) if v is not None else "—" for v in row]
+    for row in rendered.iter_rows():
         # Truncate long values
-        values = [v[:w] if len(v) > w else v for v, w in zip(values, widths, strict=True)]
+        values = [v[:w] if len(v) > w else v for v, w in zip(row, widths, strict=True)]
         print(fmt.format(*values))
 
     print(f"\n[{df.shape[0]} rows]")

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -125,7 +125,6 @@ def _load_metadata_types(csv_dir: Path) -> dict[str, type[pl.DataType]]:
 def parse_csv_bytes(
     content: bytes | memoryview,
     metadata_types: dict[str, type[pl.DataType]] | None = None,
-    _fallback_overrides: dict[str, type[pl.DataType]] | None = None,
     wanted_columns: set[str] | None = None,
 ) -> pl.DataFrame:
     """Parse CSV bytes into a Polars DataFrame, applying metadata type overrides.
@@ -134,8 +133,6 @@ def parse_csv_bytes(
         content: Raw CSV bytes (UTF-8 encoded); a memoryview is accepted so
             callers can pass a zero-copy view from ``utf8_meteoswiss_csv``.
         metadata_types: Optional parameter→dtype mapping from metadata.
-        _fallback_overrides: If provided, any Float64 fallback overrides applied
-            during error recovery will be written into this dict (for diagnostics).
         wanted_columns: Only parse these columns (intersected with the file's own
             header, so a station missing one is not an error — the diagonal concat
             fills it with nulls exactly as before). A station file is ~42 columns
@@ -198,8 +195,6 @@ def parse_csv_bytes(
             if use_columns is not None and m.group(1) not in use_columns:
                 break  # not a column we're reading; widening it would be rejected
             overrides[m.group(1)] = pl.Float64
-            if _fallback_overrides is not None:
-                _fallback_overrides[m.group(1)] = pl.Float64
             try:
                 return pl.read_csv(
                     data,

--- a/src/foehn/mcp_server.py
+++ b/src/foehn/mcp_server.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-import polars as pl
 from mcp.server.mcpserver import MCPServer
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
@@ -159,47 +158,6 @@ class GridSummary(BaseModel):
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
-def _load_and_filter(
-    dataset: str,
-    station: list[str] | None,
-    frequency: str | None,
-    time_slice: str | None,
-    year: list[int] | None,
-    month: list[int] | None,
-    date_from: str | None,
-    date_to: str | None,
-    columns: list[str] | None,
-    drop_null: str | None,
-    sort: str | None,
-    limit: int | None = None,
-) -> pl.DataFrame:
-    """Load a dataset and apply all filters via foehn.load()."""
-    kwargs: dict = {}
-    if station:
-        kwargs["station"] = station
-    if frequency:
-        kwargs["frequency"] = frequency
-    if time_slice:
-        kwargs["time_slice"] = time_slice
-    if year:
-        kwargs["year"] = year
-    if month:
-        kwargs["month"] = month
-    if date_from:
-        kwargs["date_from"] = date_from
-    if date_to:
-        kwargs["date_to"] = date_to
-    if columns:
-        kwargs["columns"] = columns
-    if drop_null:
-        kwargs["drop_null"] = drop_null
-    if sort:
-        kwargs["sort"] = sort
-    if limit is not None:
-        kwargs["limit"] = limit
-    return foehn.load(dataset, **kwargs)
-
-
 # ── Tools ────────────────────────────────────────────────────────────────────
 
 
@@ -292,18 +250,18 @@ def load_data(
 
     limit = min(max(1, limit), 500)
 
-    df = _load_and_filter(
+    df = foehn.load(
         dataset,
-        station,
-        frequency,
-        time_slice,
-        year,
-        month,
-        date_from,
-        date_to,
-        columns,
-        drop_null,
-        sort,
+        station=station,
+        frequency=frequency,
+        time_slice=time_slice,
+        year=year,
+        month=month,
+        date_from=date_from,
+        date_to=date_to,
+        columns=columns,
+        drop_null=drop_null,
+        sort=sort,
         limit=limit,
     )
     return df.to_dicts()
@@ -358,18 +316,16 @@ def describe_data(
     if time_slice and time_slice.lower() not in _VALID_TIME_SLICES:
         raise ValueError(f"Invalid time_slice {time_slice!r}. Valid options: historical, recent, now.")
 
-    df = _load_and_filter(
+    df = foehn.load(
         dataset,
-        station,
-        frequency,
-        time_slice,
-        year,
-        month,
-        date_from,
-        date_to,
-        columns=None,
+        station=station,
+        frequency=frequency,
+        time_slice=time_slice,
+        year=year,
+        month=month,
+        date_from=date_from,
+        date_to=date_to,
         drop_null=drop_null,
-        sort=None,
     )
 
     stations = sorted(df["station_abbr"].unique().to_list()) if "station_abbr" in df.columns else []

--- a/src/foehn/registry.py
+++ b/src/foehn/registry.py
@@ -118,6 +118,9 @@ class KindSpec:
     key_columns: tuple[str, ...] = ("station_abbr", "reference_timestamp")
     """Columns an explicit ``columns=`` selection always keeps."""
 
+    sort_column: str = "reference_timestamp"
+    """What ``sort=`` orders by. The nominal-date kind has no real timestamp."""
+
 
 KINDS: dict[DatasetKind, KindSpec] = {
     DatasetKind.STANDARD_CSV: KindSpec(
@@ -136,6 +139,8 @@ KINDS: dict[DatasetKind, KindSpec] = {
         # filters would silently match nothing.
         supports_calendar_filters=False,
         key_columns=("station_abbr", "variable", "gwl", "date"),
+        # Nominal dates, so ``date`` is a lexically-ordered string, not a timestamp.
+        sort_column="date",
     ),
     DatasetKind.ARCHIVE_CSV: KindSpec(
         download=_download_archive,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -783,11 +783,11 @@ def test_date_to_bare_date_includes_the_whole_final_day():
         }
     ).with_columns(pl.col("reference_timestamp").str.to_datetime())
 
-    out = _apply_post_filters(df, date_from="2025-08-30", date_to="2025-08-31")
+    out = _apply_post_filters(df, "smn", date_from="2025-08-30", date_to="2025-08-31")
     assert len(out) == 4
 
     # The day after is still excluded — the bound is the next midnight, exclusive.
-    assert len(_apply_post_filters(df, date_to="2025-08-30")) == 1
+    assert len(_apply_post_filters(df, "smn", date_to="2025-08-30")) == 1
 
 
 def test_date_to_with_explicit_time_stays_an_exact_bound():
@@ -801,7 +801,7 @@ def test_date_to_with_explicit_time_stays_an_exact_bound():
         }
     ).with_columns(pl.col("reference_timestamp").str.to_datetime())
 
-    out = _apply_post_filters(df, date_to="2025-08-31 12:00:00")
+    out = _apply_post_filters(df, "smn", date_to="2025-08-31 12:00:00")
     assert len(out) == 2
 
 
@@ -819,7 +819,7 @@ def test_date_filter_on_date_typed_column_does_not_raise():
     )
     assert df["reference_timestamp"].dtype == pl.Date  # guard: column really is Date-typed
 
-    out = _apply_post_filters(df, date_from="2025-03-01", date_to="2025-08-31")
+    out = _apply_post_filters(df, "smn", date_from="2025-03-01", date_to="2025-08-31")
     assert len(out) == 1
     assert out["reference_timestamp"][0] == date(2025, 6, 1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the CLI argument handling."""
 
+from datetime import datetime
 from unittest.mock import patch
 
 import polars as pl
@@ -425,6 +426,30 @@ def test_metadata_inventory(capsys):
     out = capsys.readouterr().out
     assert "BER" in out
     assert "tre200d0" in out
+
+
+def test_metadata_column_width_matches_what_is_printed(capsys):
+    """Width is measured from the same strings that get printed.
+
+    Measuring in Polars while printing Python's ``str()`` looked equivalent but
+    is not for Datetime: the cast renders microseconds (26 chars) where str()
+    gives 19, so the column was padded wider than anything in it. Latent while
+    the metadata frames are all strings — this pins it shut.
+    """
+    fake_df = pl.DataFrame({"when": [datetime(2026, 1, 1), None], "name": ["Bern", "Zurich"]})
+    with (
+        patch("foehn.cli.stations", return_value=fake_df),
+        patch("sys.argv", ["foehn", "metadata", "stations", "smn"]),
+    ):
+        main()
+
+    body = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    rule = next(line for line in body if line.startswith("─"))
+    rows = [line for line in body if line and not line.startswith(("─", "when", "["))]
+    when_width = len(rule.split("  ")[0])
+
+    assert when_width == max(len(row.split("  ")[0].rstrip()) for row in rows)
+    assert "—" in "".join(rows)  # nulls still render as a dash
 
 
 def test_metadata_empty(capsys):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -214,14 +214,19 @@ class TestLoadData:
         assert isinstance(result, list)
         assert len(result) == 2
         assert result[0]["station"] == "BER"
-        mock_load.assert_called_once_with("smn", limit=50)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["limit"] == 50
 
     @patch("foehn.mcp_server.foehn.load")
     def test_with_all_kwargs(self, mock_load):
         mock_load.return_value = _make_df([{"station": "BER", "temp": 20.5}])
         result = load_data("smn", station=["BER"], frequency="d", time_slice="recent", limit=10)
         assert len(result) == 1
-        mock_load.assert_called_once_with("smn", station=["BER"], frequency="d", time_slice="recent", limit=10)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["station"] == ["BER"]
+        assert mock_load.call_args.kwargs["frequency"] == "d"
+        assert mock_load.call_args.kwargs["time_slice"] == "recent"
+        assert mock_load.call_args.kwargs["limit"] == 10
 
     @patch("foehn.mcp_server.foehn.load")
     def test_limit_caps_at_500(self, mock_load):
@@ -230,14 +235,16 @@ class TestLoadData:
         mock_load.return_value = _make_df(rows)
         result = load_data("smn", limit=9999)
         assert len(result) == 500
-        mock_load.assert_called_once_with("smn", limit=500)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["limit"] == 500
 
     @patch("foehn.mcp_server.foehn.load")
     def test_limit_minimum_is_1(self, mock_load):
         mock_load.return_value = _make_df([{"station": "BER", "temp": 20.5}])
         result = load_data("smn", limit=-5)
         assert len(result) == 1
-        mock_load.assert_called_once_with("smn", limit=1)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["limit"] == 1
 
     @patch("foehn.mcp_server.foehn.load")
     def test_default_limit_is_50(self, mock_load):
@@ -245,7 +252,8 @@ class TestLoadData:
         mock_load.return_value = _make_df(rows)
         result = load_data("smn")
         assert len(result) == 50
-        mock_load.assert_called_once_with("smn", limit=50)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["limit"] == 50
 
     def test_unknown_dataset_raises(self):
         with pytest.raises(ValueError, match="Unknown dataset"):
@@ -272,7 +280,8 @@ class TestLoadData:
         """When station/frequency/time_slice are None, they should not appear in kwargs."""
         mock_load.return_value = _make_df([{"x": 1}])
         load_data("smn", station=None, frequency=None, time_slice=None)
-        mock_load.assert_called_once_with("smn", limit=50)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["limit"] == 50
 
     @patch("foehn.mcp_server.foehn.load")
     def test_returns_list_of_dicts(self, mock_load):
@@ -288,7 +297,9 @@ class TestLoadData:
             {"station_abbr": ["BER"], "reference_timestamp": [datetime(2025, 1, 1)], "temp": [20.0]}
         )
         load_data("smn", year=[2025], limit=500)
-        mock_load.assert_called_once_with("smn", year=[2025], limit=500)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["year"] == [2025]
+        assert mock_load.call_args.kwargs["limit"] == 500
 
     @patch("foehn.mcp_server.foehn.load")
     def test_month_filter_passed_to_load(self, mock_load):
@@ -296,7 +307,9 @@ class TestLoadData:
             {"station_abbr": ["BER"], "reference_timestamp": [datetime(2025, 6, 1)], "temp": [20.0]}
         )
         load_data("smn", month=[6, 7], limit=500)
-        mock_load.assert_called_once_with("smn", month=[6, 7], limit=500)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["month"] == [6, 7]
+        assert mock_load.call_args.kwargs["limit"] == 500
 
     @patch("foehn.mcp_server.foehn.load")
     def test_date_range_passed_to_load(self, mock_load):
@@ -304,7 +317,10 @@ class TestLoadData:
             {"station_abbr": ["BER"], "reference_timestamp": [datetime(2025, 6, 1)], "temp": [20.0]}
         )
         load_data("smn", date_from="2025-06-01", date_to="2025-08-31", limit=500)
-        mock_load.assert_called_once_with("smn", date_from="2025-06-01", date_to="2025-08-31", limit=500)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["date_from"] == "2025-06-01"
+        assert mock_load.call_args.kwargs["date_to"] == "2025-08-31"
+        assert mock_load.call_args.kwargs["limit"] == 500
 
     @patch("foehn.mcp_server.foehn.load")
     def test_columns_passed_to_load(self, mock_load):
@@ -312,7 +328,9 @@ class TestLoadData:
             {"station_abbr": ["BER"], "reference_timestamp": [datetime(2025, 1, 1)], "temp": [20.0]}
         )
         load_data("smn", columns=["temp"], limit=500)
-        mock_load.assert_called_once_with("smn", columns=["temp"], limit=500)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["columns"] == ["temp"]
+        assert mock_load.call_args.kwargs["limit"] == 500
 
     @patch("foehn.mcp_server.foehn.load")
     def test_drop_null_passed_to_load(self, mock_load):
@@ -320,7 +338,9 @@ class TestLoadData:
             {"station_abbr": ["BER"], "reference_timestamp": [datetime(2025, 1, 1)], "hail": [3]}
         )
         load_data("smn", drop_null="hail", limit=500)
-        mock_load.assert_called_once_with("smn", drop_null="hail", limit=500)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["drop_null"] == "hail"
+        assert mock_load.call_args.kwargs["limit"] == 500
 
     @patch("foehn.mcp_server.foehn.load")
     def test_sort_passed_to_load(self, mock_load):
@@ -328,7 +348,9 @@ class TestLoadData:
             {"station_abbr": ["BER"], "reference_timestamp": [datetime(2025, 1, 1)], "temp": [20.0]}
         )
         load_data("smn", sort="desc", limit=500)
-        mock_load.assert_called_once_with("smn", sort="desc", limit=500)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["sort"] == "desc"
+        assert mock_load.call_args.kwargs["limit"] == 500
 
     @patch("foehn.mcp_server.foehn.load")
     def test_all_filters_combined_passed_to_load(self, mock_load):
@@ -346,16 +368,20 @@ class TestLoadData:
             sort="desc",
             limit=500,
         )
-        mock_load.assert_called_once_with(
-            "smn",
-            station=["BER"],
-            frequency="d",
-            time_slice="historical",
-            year=[2025],
-            month=[7],
-            columns=["temp"],
-            sort="desc",
-            limit=500,
+        assert mock_load.call_args.args == ("smn",)
+        assert (
+            mock_load.call_args.kwargs
+            | {
+                "station": ["BER"],
+                "frequency": "d",
+                "time_slice": "historical",
+                "year": [2025],
+                "month": [7],
+                "columns": ["temp"],
+                "sort": "desc",
+                "limit": 500,
+            }
+            == mock_load.call_args.kwargs
         )
 
     def test_invalid_sort_raises(self):
@@ -377,7 +403,9 @@ class TestLoadData:
         assert len(result) == 2
         assert result[0]["temp"] == -1.0  # December
         assert result[1]["temp"] == 15.0  # September
-        mock_load.assert_called_once_with("smn", sort="desc", limit=2)
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["sort"] == "desc"
+        assert mock_load.call_args.kwargs["limit"] == 2
 
 
 # ── describe_data ────────────────────────────────────────────────────────────
@@ -431,7 +459,8 @@ class TestDescribeData:
             }
         )
         result = describe_data("smn", year=[2025])
-        mock_load.assert_called_once_with("smn", year=[2025])
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["year"] == [2025]
         assert result.total_rows == 1
 
     @patch("foehn.mcp_server.foehn.load")
@@ -444,7 +473,8 @@ class TestDescribeData:
             }
         )
         result = describe_data("smn", month=[7])
-        mock_load.assert_called_once_with("smn", month=[7])
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["month"] == [7]
         assert result.total_rows == 1
 
     @patch("foehn.mcp_server.foehn.load")
@@ -457,7 +487,9 @@ class TestDescribeData:
             }
         )
         result = describe_data("smn", date_from="2025-06-01", date_to="2025-08-31")
-        mock_load.assert_called_once_with("smn", date_from="2025-06-01", date_to="2025-08-31")
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["date_from"] == "2025-06-01"
+        assert mock_load.call_args.kwargs["date_to"] == "2025-08-31"
         assert result.total_rows == 1
 
     @patch("foehn.mcp_server.foehn.load")
@@ -470,7 +502,8 @@ class TestDescribeData:
             }
         )
         result = describe_data("smn", drop_null="hail")
-        mock_load.assert_called_once_with("smn", drop_null="hail")
+        assert mock_load.call_args.args == ("smn",)
+        assert mock_load.call_args.kwargs["drop_null"] == "hail"
         assert result.total_rows == 1
         assert result.stations == ["BER"]
 


### PR DESCRIPTION
Four leftovers from the architecture review and the code review, grouped because each is small.

## 1. A dead out-parameter — `convert.py`

`parse_csv_bytes` took `_fallback_overrides`, documented it, and wrote into it at line 201. Nothing in `src/`, `scripts/` or `tests/` ever passed it. Deleted.

## 2. Column widths that don't match what's printed — `cli.py`

`cmd_metadata` measured widths in Polars but printed Python's `str()`. Equivalent for strings and dates; **not** for `Datetime` — the Utf8 cast renders microseconds, so a timestamp measures 26 characters against `str()`'s 19 and the column prints padded wider than anything in it.

Latent today: `_fetch_metadata_csv` calls `pl.read_csv` without `try_parse_dates`, so `parameters`/`stations`/`inventory` carry no Datetime column. It activates the moment one does.

Measuring and printing now both come from one Utf8 projection, so they can't drift apart — and the measurement stays off the pure-Python path, which was the point of the original change. Nulls still render as `—`.

## 3. `keep_cols` crossing the seam — `api.py`

`_apply_post_filters` took `keep_cols` from its caller, so each load path stated its own schema across that boundary. It reads `key_columns` from the kind's spec now.

Adding `sort_column` to `KindSpec` alongside it collapses a third copy: `_load_climate_scenarios` was hand-rolling the same drop_null/sort/columns/limit block, differing only in sorting on `date` rather than `reference_timestamp`. It uses the shared pass now. (Its calendar filters are already rejected upstream for that kind, so the time-filtering half is a no-op there.)

## 4. `_load_and_filter` — `mcp_server.py`

Twelve parameters in, twelve kwargs out; its only behaviour was dropping falsy values. Deleted — both tools call `foehn.load` directly.

**One behaviour change worth a look.** The single fact that helper carried is that an empty list means "no filter". That moves into `load()`, so `load(station=[])` and `load(frequency=[])` now mean "all" rather than "match nothing". The old semantics were reachable only through the Python API (the MCP layer always stripped empty lists), and "match nothing" is never what a caller wants — but it is a public semantic change, so flagging it rather than burying it.

The MCP tests that asserted the stripping now assert forwarding instead, since the stripping is what got deleted.

## Verification

- 427 tests pass; coverage 90.3% → 90.6%, `api.py` 91% → 94%, `mcp_server.py` at 100%
- ruff, `ty` and both live tests clean
- Smoke-tested against the live API: `columns=` still keeps the right key columns, `station=[]` now returns rows, and `foehn metadata stations smn` renders correctly