### PR TITLE
Deepen the STAC listing into an asset module

### DIFF
--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import polars as pl
 
 from foehn import registry
-from foehn._urls import asset_filename, clean_href
+from foehn._urls import asset_filename
+from foehn.assets import assets_of, collection_assets, hrefs, select
 from foehn.client import (
     DownloadResult,
     _check_zip_size,
@@ -18,9 +19,7 @@ from foehn.collections import (
     COLLECTION_META,
     COLLECTIONS,
     DatasetKind,
-    forecast_run_from_filename,
     kind,
-    time_slice_from_filename,
 )
 from foehn.convert import (
     _parse_metadata_types,
@@ -157,11 +156,9 @@ def _fetch_metadata_csv(dataset: str, suffix: str) -> pl.DataFrame:
     fetcher = default_fetcher()
 
     coll = fetcher.collection(collection_id)
-    for asset_info in coll.get("assets", {}).values():
-        href = asset_info.get("href", "")
-        if clean_href(href).endswith(".csv") and suffix in href:
-            content = decode_meteoswiss_csv(fetcher.get(href, timeout=60).body)
-            return pl.read_csv(content.encode("utf-8"), separator=";")
+    for asset in collection_assets(coll, suffixes=(".csv",), contains=suffix):
+        content = decode_meteoswiss_csv(fetcher.get(asset.href, timeout=60).body)
+        return pl.read_csv(content.encode("utf-8"), separator=";")
 
     raise ValueError(f"No {suffix} metadata found for dataset {dataset!r}.")
 
@@ -356,17 +353,10 @@ def _load_indoor(
     collection_id = COLLECTIONS[dataset]
     fetcher = default_fetcher()
     items = fetcher.items(collection_id)
-    zip_href = next(
-        (
-            asset_info.get("href", "")
-            for item in items
-            for asset_info in item.get("assets", {}).values()
-            if clean_href(asset_info.get("href", "")).endswith(".zip")
-        ),
-        None,
-    )
-    if not zip_href:
+    archives = assets_of(items, suffixes=(".zip",))
+    if not archives:
         raise ValueError(f"No .zip asset found for {dataset!r}.")
+    zip_href = archives[0].href
 
     station_filter: set[str] | None = None
     if station is not None:
@@ -436,15 +426,8 @@ def _load_climate_scenarios(
     if station_filter is not None:
         items = [item for item in items if item.get("id", "").lower() in station_filter]
 
-    hrefs: list[str] = []
-    for item in items:
-        for asset_info in item.get("assets", {}).values():
-            href = asset_info.get("href", "")
-            filename = asset_filename(href)
-            if filename.endswith(".csv") and "_meta_" not in filename:
-                hrefs.append(href)
-
-    if not hrefs:
+    csv_hrefs = hrefs(assets_of(items, suffixes=(".csv",), excludes="_meta_"))
+    if not csv_hrefs:
         raise ValueError(f"No climate-scenario CSVs found for {dataset!r} with station={station}.")
 
     # The fetcher is safe to share across the pool: it hands each worker thread
@@ -452,11 +435,11 @@ def _load_climate_scenarios(
     def _fetch(href: str) -> pl.DataFrame:
         return parse_climate_scenarios_csv(fetcher.get(href, timeout=120).body, asset_filename(href))
 
-    if len(hrefs) == 1 or workers <= 1:
-        frames = [_fetch(h) for h in hrefs]
+    if len(csv_hrefs) == 1 or workers <= 1:
+        frames = [_fetch(h) for h in csv_hrefs]
     else:
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            frames = list(pool.map(_fetch, hrefs))
+            frames = list(pool.map(_fetch, csv_hrefs))
 
     df = pl.concat(frames, how="diagonal_relaxed")
     # The calendar filters are rejected for this kind before we get here, so the
@@ -606,11 +589,9 @@ def load(
     # 1. Fetch metadata types for schema inference.
     metadata_types: dict[str, type[pl.DataType]] = {}
     coll = fetcher.collection(collection_id)
-    for asset_info in coll.get("assets", {}).values():
-        href = asset_info.get("href", "")
-        if clean_href(href).endswith(".csv") and "_meta_parameters" in href:
-            metadata_types = _parse_metadata_types(decode_meteoswiss_csv(fetcher.get(href, timeout=60).body))
-            break
+    for asset in collection_assets(coll, suffixes=(".csv",), contains="_meta_parameters"):
+        metadata_types = _parse_metadata_types(decode_meteoswiss_csv(fetcher.get(asset.href, timeout=60).body))
+        break
 
     # 2. Get STAC items and collect matching CSV URLs.
     items = fetcher.items(collection_id)
@@ -626,35 +607,17 @@ def load(
     if kind(dataset) is DatasetKind.FORECAST_CSV and items:
         items.sort(key=lambda x: x.get("id", ""))
 
-    skip_data_type_filter = kind(dataset) is DatasetKind.FORECAST_CSV
-    csv_hrefs: list[str] = []
-    for item in items:
-        assets = item.get("assets", {})
-        for asset_info in assets.values():
-            href = asset_info.get("href", "")
-            filename = asset_filename(href)
-            if not filename.endswith(".csv"):
-                continue
-            # Filter by frequency — encoded as _{f}_ or _{f}. in the filename.
-            if freq_filter is not None:
-                parts = filename.rsplit(".", 1)[0].split("_")
-                # Frequency is the segment after the station abbr (e.g. ogd-smn_ber_d_recent)
-                file_freq = parts[2] if len(parts) > 2 else None
-                if file_freq not in freq_filter:
-                    continue
-            if not skip_data_type_filter:
-                slice_ = time_slice_from_filename(filename)
-                if slice_ is not None and slice_ not in time_slice:
-                    continue
-            csv_hrefs.append(href)
-
-    # Narrow forecasts to the newest model run — the retained window holds ~40 runs
-    # of ~32 files each, and load() wants the current forecast, not all of them.
-    if kind(dataset) is DatasetKind.FORECAST_CSV and csv_hrefs:
-        runs = {run for href in csv_hrefs if (run := forecast_run_from_filename(clean_href(href))) is not None}
-        if runs:
-            latest_run = max(runs)
-            csv_hrefs = [href for href in csv_hrefs if forecast_run_from_filename(clean_href(href)) == latest_run]
+    # Forecast filenames carry no time slice; load() wants the current forecast,
+    # so narrowing to the newest run is what bounds them instead.
+    is_forecast = kind(dataset) is DatasetKind.FORECAST_CSV
+    csv_hrefs = hrefs(
+        select(
+            assets_of(items, suffixes=(".csv",)),
+            time_slices=None if is_forecast else time_slice,
+            granularities=freq_filter,
+            latest_run=is_forecast,
+        )
+    )
 
     if not csv_hrefs:
         filters = f"station={station}, frequency={frequency}, time_slice={time_slice}"

--- a/src/foehn/assets.py
+++ b/src/foehn/assets.py
@@ -1,0 +1,187 @@
+"""STAC assets, with the facts their filenames carry already parsed out.
+
+The listing comes back from :mod:`foehn.fetch` as raw STAC dicts, because what
+a time slice or a forecast run *is* belongs to MeteoSwiss, not to the transport.
+Turning those dicts into :class:`Asset` values, and picking the ones a call
+wants, happens here — in one place rather than in each caller.
+
+Before this module, every download and load path walked ``item["assets"]``
+itself, stripped the query string itself, and re-derived the slice and run from
+the filename itself. The forecast-run rule in particular — collect the runs,
+take ``max()``, keep only that one — was written out twice, in
+``client.download_collection`` and in ``api.load``, and had to stay in step for
+the two to agree on which forecast you get.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from foehn._urls import asset_filename
+from foehn.collections import (
+    forecast_run_from_filename,
+    granularity_from_filename,
+    time_slice_from_filename,
+)
+
+
+@dataclass(frozen=True)
+class Asset:
+    """One downloadable file in a STAC listing.
+
+    ``href`` keeps its query string, because that is what has to be fetched;
+    every other field is derived from the query-stripped name, because that is
+    what carries meaning. Callers that used to hold a bare href string had to
+    remember which of the two they were holding at each step.
+    """
+
+    href: str
+    name: str
+    key: str
+    """The asset's key in the item, which is how collection-level assets are found."""
+
+    updated: str
+    """Per-asset ``updated`` when the API gives one, else the item's."""
+
+    item_id: str
+    time_slice: str | None
+    granularity: str | None
+    forecast_run: str | None
+
+    @classmethod
+    def from_stac(cls, key: str, asset: dict, *, item_id: str = "", item_updated: str = "") -> Asset:
+        href = asset.get("href", "")
+        name = asset_filename(href)
+        return cls(
+            href=href,
+            name=name,
+            key=key,
+            # STAC allows a per-asset updated; fall back to the item's.
+            updated=asset.get("updated") or item_updated,
+            item_id=item_id,
+            time_slice=time_slice_from_filename(name),
+            granularity=granularity_from_filename(name),
+            forecast_run=forecast_run_from_filename(name),
+        )
+
+    @property
+    def extension(self) -> str:
+        """Lowercased suffix including the dot, or "" if the name carries none."""
+        _, dot, ext = self.name.rpartition(".")
+        return f".{ext.lower()}" if dot else ""
+
+
+def assets_of(
+    items: Iterable[dict],
+    *,
+    suffixes: tuple[str, ...] | None = None,
+    contains: str | None = None,
+    excludes: str | None = None,
+) -> list[Asset]:
+    """Every asset across *items*, narrowed by name.
+
+    ``suffixes`` keeps only those file types, ``contains`` only names holding
+    that substring, ``excludes`` drops names holding it (``_meta_``, mostly).
+    All three match the query-stripped name, which is the bug this replaces:
+    ``href.endswith(".csv")`` silently drops an asset served with a token.
+    """
+    found: list[Asset] = []
+    for item in items:
+        item_id = item.get("id", "")
+        item_updated = item.get("properties", {}).get("updated", "")
+        for key, info in item.get("assets", {}).items():
+            asset = Asset.from_stac(key, info, item_id=item_id, item_updated=item_updated)
+            if suffixes is not None and not asset.name.endswith(suffixes):
+                continue
+            if contains is not None and contains not in asset.name:
+                continue
+            if excludes is not None and excludes in asset.name:
+                continue
+            found.append(asset)
+    return found
+
+
+def collection_assets(
+    collection: dict,
+    *,
+    suffixes: tuple[str, ...] | None = None,
+    contains: str | None = None,
+    key_contains: str | None = None,
+) -> list[Asset]:
+    """Assets hanging off the collection itself rather than off its items.
+
+    These are the metadata files — parameters, stations, inventory — and the
+    GRIB2 constants. ``key_contains`` matches the asset's key rather than its
+    name, which is how the constants file is identified.
+    """
+    found = assets_of([collection], suffixes=suffixes, contains=contains)
+    if key_contains is not None:
+        found = [a for a in found if key_contains in a.key.lower()]
+    return found
+
+
+def select(
+    assets: Iterable[Asset],
+    *,
+    time_slices: Iterable[str] | None = None,
+    granularities: Iterable[str] | None = None,
+    latest_run: bool = False,
+) -> list[Asset]:
+    """Narrow *assets* to what a call actually wants.
+
+    ``time_slices`` keeps assets in those slices, and keeps assets that have no
+    slice at all — a file with no slice segment is unsliced data that every
+    query includes, not data that matches nothing.
+
+    ``latest_run`` keeps only the newest forecast run. A forecast item is one
+    *day* holding that day's runs, so picking the newest item is not the same
+    thing and picks an empty one: the newest day is created at ~04:00 UTC and
+    filled as its runs publish. Runs are zero-padded ``YYYYMMDDHHMM``, so the
+    newest is ``max()`` without parsing a datetime. One run is ~32 files at
+    ~30 MB; the retained window is ~40 runs.
+    """
+    found = list(assets)
+
+    if time_slices is not None:
+        wanted = set(time_slices)
+        found = [a for a in found if a.time_slice is None or a.time_slice in wanted]
+
+    if granularities is not None:
+        wanted = set(granularities)
+        found = [a for a in found if a.granularity in wanted]
+
+    if latest_run:
+        runs = {a.forecast_run for a in found if a.forecast_run is not None}
+        if runs:
+            newest = max(runs)
+            found = [a for a in found if a.forecast_run == newest]
+
+    return found
+
+
+def latest_run_of(assets: Iterable[Asset]) -> str | None:
+    """The newest forecast run present, for callers that want to log it."""
+    runs = {a.forecast_run for a in assets if a.forecast_run is not None}
+    return max(runs) if runs else None
+
+
+def hrefs(assets: Iterable[Asset]) -> list[str]:
+    """Just the fetchable hrefs, for callers that need nothing else."""
+    return [a.href for a in assets]
+
+
+def other_extensions(items: Iterable[dict]) -> set[str]:
+    """Extensions present in *items* — for telling a caller what a collection does hold."""
+    return {ext for a in assets_of(items) if (ext := a.extension)}
+
+
+__all__ = [
+    "Asset",
+    "assets_of",
+    "collection_assets",
+    "hrefs",
+    "latest_run_of",
+    "other_extensions",
+    "select",
+]

--- a/src/foehn/client.py
+++ b/src/foehn/client.py
@@ -10,14 +10,12 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-from foehn._urls import asset_filename, clean_href
+from foehn.assets import assets_of, collection_assets, latest_run_of, select
 from foehn.collections import (
     CLIMATE_NORMALS_ZIP_URL,
     COLLECTIONS,
     DatasetKind,
-    forecast_run_from_filename,
     kind,
-    time_slice_from_filename,
 )
 from foehn.convert import utf8_meteoswiss_csv
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
@@ -205,36 +203,21 @@ def download_collection(
     # picked out of the filenames below. (Ordering the items buys nothing: the run
     # is chosen with max(), and downloads complete out of order regardless.)
 
-    # Collect matching CSV assets. ``all_csv_hrefs`` is the full pre-filter set
-    # (every CSV in the listing, regardless of time slice) — the prune universe
-    # below, so ETags for slices outside this run's data_types are kept.
-    skip_data_type_filter = kind(collection_key) is DatasetKind.FORECAST_CSV
-    csv_assets = []
-    all_csv_hrefs: set[str] = set()
-    for item in items:
-        assets = item.get("assets", {})
-        for asset_info in assets.values():
-            href = asset_info.get("href", "")
-            clean = clean_href(href)
-            if not clean.endswith(".csv"):
-                continue
-            all_csv_hrefs.add(href)
-            if not skip_data_type_filter:
-                slice_ = time_slice_from_filename(clean)
-                if slice_ is not None and slice_ not in data_types:
-                    continue
-            csv_assets.append((href, asset_info))
-
+    # ``every_csv`` is the full pre-filter set — the prune universe below, so
+    # ETags for slices outside this run's data_types are kept.
+    is_forecast = kind(collection_key) is DatasetKind.FORECAST_CSV
+    every_csv = assets_of(items, suffixes=(".csv",))
     # One forecast run is ~32 files at ~30 MB each (~1 GB); the full retained
-    # window is ~40 runs (~40 GB). Keep only the newest complete-ish run.
-    if kind(collection_key) is DatasetKind.FORECAST_CSV and csv_assets:
-        runs = {run for href, _ in csv_assets if (run := forecast_run_from_filename(clean_href(href))) is not None}
-        if runs:
-            latest_run = max(runs)
-            csv_assets = [
-                (href, info) for href, info in csv_assets if forecast_run_from_filename(clean_href(href)) == latest_run
-            ]
-            logger.info("  Latest forecast run: %s (of %d available)", latest_run, len(runs))
+    # window is ~40 runs (~40 GB). Forecast filenames carry no time slice, so
+    # narrowing to the newest run is what bounds them instead.
+    csv_assets = select(
+        every_csv,
+        time_slices=None if is_forecast else data_types,
+        latest_run=is_forecast,
+    )
+    if is_forecast and (run := latest_run_of(every_csv)) is not None:
+        available = len({a.forecast_run for a in every_csv if a.forecast_run is not None})
+        logger.info("  Latest forecast run: %s (of %d available)", run, available)
 
     logger.info("  %d CSV files to process", len(csv_assets))
 
@@ -246,7 +229,7 @@ def download_collection(
     skipped = 0
     failed = 0
     filenames: list[str] = []
-    fetch_targets = _dedupe_by_destination([(href, out_dir / asset_filename(href)) for href, _ in csv_assets])
+    fetch_targets = _dedupe_by_destination([(a.href, out_dir / a.name) for a in csv_assets])
     with ThreadPoolExecutor(max_workers=workers) as pool:
         future_to_href = {
             pool.submit(_do_csv, href, filepath, etags.get(href)): href for href, filepath in fetch_targets
@@ -280,7 +263,8 @@ def download_collection(
     # after failures the universe may be incomplete.
     if since is None and failed == 0:
         prefix = f"/{collection_id}/"
-        stale = [k for k in etags if prefix in k and k not in all_csv_hrefs]
+        listed = {a.href for a in every_csv}
+        stale = [k for k in etags if prefix in k and k not in listed]
         for k in stale:
             del etags[k]
         if stale:
@@ -310,17 +294,7 @@ def download_metadata(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     coll = fetcher.collection(collection_id)
-    assets = coll.get("assets", {})
-    if not assets:
-        return DownloadResult()
-
-    targets = _dedupe_by_destination(
-        [
-            (asset_info["href"], out_dir / asset_filename(asset_info["href"]))
-            for asset_info in assets.values()
-            if clean_href(asset_info.get("href", "")).endswith(".csv")
-        ]
-    )
+    targets = _dedupe_by_destination([(a.href, out_dir / a.name) for a in collection_assets(coll, suffixes=(".csv",))])
     if not targets:
         return DownloadResult()
 
@@ -405,28 +379,11 @@ def download_grib2(
             logger.info("  Nothing changed — skipping")
             return DownloadResult()
 
-    binary_assets = []
-    for item in items:
-        item_updated = item.get("properties", {}).get("updated", "")
-        assets = item.get("assets", {})
-        for asset_info in assets.values():
-            href = asset_info.get("href", "")
-            clean = clean_href(href)
-            # Accept grib2, h5, and other binary formats
-            if any(clean.endswith(ext) for ext in (".grib2", ".h5", ".hdf5")):
-                # Per-asset "updated" is preferred when present (STAC allows it),
-                # otherwise fall back to the item-level updated timestamp.
-                updated = asset_info.get("updated") or item_updated
-                binary_assets.append((href, clean.split("/")[-1], updated))
-
+    binary_assets = assets_of(items, suffixes=(".grib2", ".h5", ".hdf5"))
     logger.info("  %d binary files to download", len(binary_assets))
 
     to_fetch = _dedupe_by_destination(
-        [
-            (href, out_dir / filename)
-            for href, filename, updated in binary_assets
-            if _needs_redownload(out_dir / filename, updated)
-        ]
+        [(a.href, out_dir / a.name) for a in binary_assets if _needs_redownload(out_dir / a.name, a.updated)]
     )
 
     def _do_binary(href: str, filepath: Path) -> str:
@@ -501,20 +458,9 @@ def download_netcdf(
             logger.info("  Nothing changed — skipping")
             return DownloadResult()
 
-    total_assets = 0
-    targets: list[tuple[str, Path]] = []
-    for item in items:
-        for asset_info in item.get("assets", {}).values():
-            href = asset_info.get("href", "")
-            clean = clean_href(href)
-            if not clean.endswith((".nc", ".tif", ".zip")):
-                continue
-            total_assets += 1
-            filepath = out_dir / clean.split("/")[-1]
-            if filepath.exists():
-                continue
-            targets.append((href, filepath))
-    targets = _dedupe_by_destination(targets)
+    spatial = assets_of(items, suffixes=(".nc", ".tif", ".zip"))
+    total_assets = len(spatial)
+    targets = _dedupe_by_destination([(a.href, out_dir / a.name) for a in spatial if not (out_dir / a.name).exists()])
 
     def _do_binary(href: str, filepath: Path) -> str:
         fetcher.stream(href, filepath)
@@ -641,16 +587,9 @@ def download_climate_scenarios_indoor(
         return DownloadResult(total_assets=1, downloaded=0, skipped=1, filenames=[])
 
     items = fetcher.items(collection_id)
-    zip_href = next(
-        (
-            asset_info.get("href", "")
-            for item in items
-            for asset_info in item.get("assets", {}).values()
-            if clean_href(asset_info.get("href", "")).endswith(".zip")
-        ),
-        None,
-    )
-    if not zip_href:
+    archives = assets_of(items, suffixes=(".zip",))
+    archive = archives[0] if archives else None
+    if archive is None:
         logger.warning("  No .zip asset found for %s", collection_key)
         return DownloadResult()
 
@@ -658,8 +597,8 @@ def download_climate_scenarios_indoor(
     logger.info("Indoor scenarios (%s): downloading ZIP", collection_id)
     logger.info("%s", "=" * 60)
 
-    zip_path = out_dir / asset_filename(zip_href)
-    fetcher.stream(zip_href, zip_path, timeout=300)
+    zip_path = out_dir / archive.name
+    fetcher.stream(archive.href, zip_path, timeout=300)
     logger.info("  Downloaded: %s (%.1f MB)", zip_path.name, zip_path.stat().st_size / 1e6)
 
     extracted = _safe_extract_zip(zip_path, out_dir)

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -498,6 +498,20 @@ def time_slice_from_filename(filename: str) -> str | None:
     return None
 
 
+def granularity_from_filename(filename: str) -> str | None:
+    """Return the granularity segment of a standard CSV asset, or None.
+
+    Standard assets are ``ogd-{key}_{station}_{granularity}[_{timeslice}].csv``,
+    so the granularity is the third underscore-separated segment
+    (``ogd-smn_ber_d_recent.csv`` -> ``"d"``). Returns None for the kinds whose
+    filenames do not carry one, rather than guessing at whatever sits in that
+    position.
+    """
+    stem = filename.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+    parts = stem.split("_")
+    return parts[2] if len(parts) > 2 else None
+
+
 # Forecast CSV assets are named ``vnut12.lssw.<YYYYMMDDHHMM>.<param>.csv``, where
 # the middle field is the model run time — i.e. when the forecast was issued. Note
 # this is NOT the "reference timestamp" of MeteoSwiss's docs, which is the ``Date``

--- a/src/foehn/grids.py
+++ b/src/foehn/grids.py
@@ -41,7 +41,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from foehn._urls import asset_filename, clean_href
+from foehn.assets import Asset, assets_of, collection_assets, other_extensions
 from foehn.collections import COLLECTION_META, COLLECTIONS, KIND_OF, DatasetKind, is_grid, kind
 from foehn.fetch import DEFAULT_WORKERS, Fetcher, FetchError, default_fetcher
 
@@ -187,25 +187,15 @@ def _raise_if_too_many(collection_key: str, match: str | None, names: list[str],
     )
 
 
-def _grid_asset_hrefs(items: list[dict], suffixes: tuple[str, ...], match: str | None) -> tuple[list[str], set[str]]:
-    """Pick the grid asset hrefs out of a STAC listing.
+def _grid_assets(items: list[dict], suffixes: tuple[str, ...], match: str | None) -> tuple[list[Asset], set[str]]:
+    """Pick the grid assets out of a STAC listing.
 
-    Returns the matching hrefs plus the other extensions seen, which feed the
+    Returns the matching assets plus the other extensions seen, which feed the
     "available asset types" hint when nothing matches.
     """
-    hrefs: list[str] = []
-    other_exts: set[str] = set()
-    for item in items:
-        for asset_info in item.get("assets", {}).values():
-            href = asset_info.get("href", "")
-            clean = clean_href(href)
-            filename = clean.split("/")[-1]
-            if clean.endswith(suffixes):
-                if match is None or match in filename:
-                    hrefs.append(href)
-            elif "." in filename:
-                other_exts.add("." + filename.rsplit(".", 1)[-1])
-    return hrefs, other_exts
+    matched = assets_of(items, suffixes=suffixes, contains=match)
+    other_exts = {ext for ext in other_extensions(items) if not ext.endswith(suffixes)}
+    return matched, other_exts
 
 
 def _ensure_grid_files(
@@ -256,17 +246,17 @@ def _ensure_grid_files(
             return cached
         raise
 
-    hrefs, other_exts = _grid_asset_hrefs(items, suffixes, match)
+    matched, other_exts = _grid_assets(items, suffixes, match)
 
-    if not hrefs and datetime_filter is not None:
+    if not matched and datetime_filter is not None:
         # The run-narrowed listing came back with nothing usable. Rather than
         # report a file as missing on the strength of an optimisation, fall back
         # to the full walk — slow, but it is exactly what happened before.
         logger.debug("No %s assets for %r under datetime=%s; retrying unfiltered", sfx, match, datetime_filter)
         items = fetcher.items(collection_id, cache=True)
-        hrefs, other_exts = _grid_asset_hrefs(items, suffixes, match)
+        matched, other_exts = _grid_assets(items, suffixes, match)
 
-    if not hrefs:
+    if not matched:
         if match is not None:
             raise ValueError(f"No {sfx} assets matching {match!r} found for {collection_key!r}.")
         found = ", ".join(sorted(other_exts)) or "none"
@@ -274,18 +264,18 @@ def _ensure_grid_files(
 
     # Enforce the per-format file cap before downloading so an over-broad match
     # (e.g. a whole forecast run) can't pull hundreds of files off the network.
-    _raise_if_too_many(collection_key, match, [asset_filename(h) for h in hrefs], max_files)
+    _raise_if_too_many(collection_key, match, [a.name for a in matched], max_files)
 
     out_dir.mkdir(parents=True, exist_ok=True)
     paths: list[Path] = []
     # Deduplicate by destination: a STAC item can list one asset under several
     # keys, and two workers streaming into the same ``.part`` would corrupt it.
     targets: dict[Path, str] = {}
-    for href in hrefs:
-        filepath = out_dir / asset_filename(href)
+    for asset in matched:
+        filepath = out_dir / asset.name
         paths.append(filepath)
         if not filepath.exists() and filepath not in targets:
-            targets[filepath] = href
+            targets[filepath] = asset.href
 
     if targets:
         # Fetch concurrently, like the CSV path. Serial downloads made the network
@@ -469,15 +459,13 @@ def _ensure_constants_file(collection_key: str, bronze_dir: Path, *, fetcher: Fe
         return cached[0]
 
     meta = fetcher.collection(COLLECTIONS[collection_key])
-    href = next(
-        (a.get("href", "") for k, a in meta.get("assets", {}).items() if "horizontal_constants" in k.lower()),
-        "",
-    )
-    if not href:
+    constants = collection_assets(meta, key_contains="horizontal_constants")
+    if not constants:
         return None
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    path = out_dir / asset_filename(href)
+    href = constants[0].href
+    path = out_dir / constants[0].name
     if not path.exists():
         fetcher.stream(href, path)
     return path

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,263 @@
+"""Tests for asset parsing and selection.
+
+The rules these cover used to live inline in the download and load paths — most
+of them in both, which is why the two could disagree about which forecast run
+you got. They belong to one module now, and so do their tests.
+"""
+
+import pytest
+
+from foehn.assets import (
+    Asset,
+    assets_of,
+    collection_assets,
+    hrefs,
+    latest_run_of,
+    other_extensions,
+    select,
+)
+
+BASE = "https://data.geo.admin.ch/x"
+
+
+def _item(item_id, *names, updated="2026-01-01T00:00:00Z", **asset_extra):
+    return {
+        "id": item_id,
+        "properties": {"updated": updated},
+        "assets": {n: {"href": f"{BASE}/{n}", **asset_extra} for n in names},
+    }
+
+
+# --- parsing -------------------------------------------------------------
+
+
+def test_asset_parses_the_filename_facts():
+    (asset,) = assets_of([_item("ber", "ogd-smn_ber_d_recent.csv")])
+
+    assert asset.name == "ogd-smn_ber_d_recent.csv"
+    assert asset.time_slice == "recent"
+    assert asset.granularity == "d"
+    assert asset.forecast_run is None
+    assert asset.item_id == "ber"
+
+
+def test_href_keeps_its_query_string_but_the_name_does_not():
+    """A CSV served with a token must still be recognised — and saved unsuffixed.
+
+    ``href.endswith(".csv")`` on the raw href silently dropped these.
+    """
+    items = [{"id": "ber", "properties": {}, "assets": {"a": {"href": f"{BASE}/ogd-smn_ber_d_recent.csv?token=abc"}}}]
+
+    (asset,) = assets_of(items, suffixes=(".csv",))
+
+    assert asset.href.endswith("?token=abc")  # what gets fetched
+    assert asset.name == "ogd-smn_ber_d_recent.csv"  # what gets written
+    assert asset.time_slice == "recent"
+
+
+def test_decade_split_historical_keeps_its_slice():
+    """The t/h historical series are split per decade, so the slice sits one
+    segment further back. Reading it as "no slice at all" makes every query
+    include the full history."""
+    (asset,) = assets_of([_item("ber", "ogd-smn_ber_t_historical_2000-2009.csv")])
+
+    assert asset.time_slice == "historical"
+    assert asset.granularity == "t"
+
+
+def test_forecast_filenames_carry_a_run_and_no_slice():
+    (asset,) = assets_of([_item("d", "vnut12.lssw.202607210600.dkl010h0.csv")])
+
+    assert asset.forecast_run == "202607210600"
+    assert asset.time_slice is None
+    assert asset.granularity is None
+
+
+def test_per_asset_updated_wins_over_the_item():
+    """STAC allows either; the binary paths compare it against local mtime."""
+    items = [
+        {
+            "id": "f",
+            "properties": {"updated": "2026-01-01T00:00:00Z"},
+            "assets": {"a": {"href": f"{BASE}/f.grib2", "updated": "2026-06-01T00:00:00Z"}},
+        }
+    ]
+
+    (asset,) = assets_of(items)
+
+    assert asset.updated == "2026-06-01T00:00:00Z"
+
+
+def test_item_updated_is_the_fallback():
+    (asset,) = assets_of([_item("f", "f.grib2", updated="2026-01-01T00:00:00Z")])
+
+    assert asset.updated == "2026-01-01T00:00:00Z"
+
+
+# --- narrowing by name ---------------------------------------------------
+
+
+def test_suffixes_filter():
+    items = [_item("g", "grid.nc", "grid.tif", "readme.pdf")]
+
+    assert {a.name for a in assets_of(items, suffixes=(".nc", ".tif"))} == {"grid.nc", "grid.tif"}
+
+
+def test_contains_and_excludes():
+    items = [_item("c", "ogd-cs_abe_pr_gwl1.5.csv", "ogd-cs_meta_parameters.csv")]
+
+    assert [a.name for a in assets_of(items, excludes="_meta_")] == ["ogd-cs_abe_pr_gwl1.5.csv"]
+    assert [a.name for a in assets_of(items, contains="_meta_")] == ["ogd-cs_meta_parameters.csv"]
+
+
+def test_other_extensions_reports_what_a_collection_does_hold():
+    """Feeds the "available asset types" hint when a match finds nothing."""
+    assert other_extensions([_item("g", "grid.tif", "bundle.zip")]) == {".tif", ".zip"}
+
+
+# --- selection -----------------------------------------------------------
+
+
+def test_time_slice_selection_keeps_unsliced_assets():
+    """A file with no slice segment is unsliced data every query includes."""
+    items = [_item("ber", "ogd-smn_ber_d_recent.csv", "ogd-smn_ber_d_historical.csv", "ogd-tot_ber.csv")]
+
+    kept = {a.name for a in select(assets_of(items, suffixes=(".csv",)), time_slices=["recent"])}
+
+    assert kept == {"ogd-smn_ber_d_recent.csv", "ogd-tot_ber.csv"}
+
+
+def test_granularity_selection_drops_assets_without_one():
+    """Unlike time slice: a file with no granularity cannot satisfy frequency=."""
+    items = [_item("ber", "ogd-smn_ber_d_recent.csv", "ogd-smn_ber_t_recent.csv", "ogd-tot_ber.csv")]
+
+    kept = {a.name for a in select(assets_of(items, suffixes=(".csv",)), granularities=["d"])}
+
+    assert kept == {"ogd-smn_ber_d_recent.csv"}
+
+
+def test_latest_run_keeps_only_the_newest():
+    """One run is ~32 files at ~30 MB; the retained window is ~40 runs."""
+    items = [
+        _item("20260721-ch", "vnut12.lssw.202607210400.dkl010h0.csv", "vnut12.lssw.202607210400.fu3010h0.csv"),
+        _item("20260721-ch", "vnut12.lssw.202607210600.dkl010h0.csv", "vnut12.lssw.202607210600.fu3010h0.csv"),
+    ]
+
+    kept = select(assets_of(items, suffixes=(".csv",)), latest_run=True)
+
+    assert {a.forecast_run for a in kept} == {"202607210600"}
+    assert len(kept) == 2  # both params of that run, not just one
+
+
+def test_latest_run_ignores_an_empty_newest_item():
+    """The newest day is created at ~04:00 UTC and filled as its runs publish.
+
+    Selecting the newest *item* therefore returned zero CSVs — issue #27. The
+    run comes from the filenames, so an empty item contributes nothing.
+    """
+    items = [
+        _item("20260721-ch", "vnut12.lssw.202607210600.dkl010h0.csv"),
+        _item("20260722-ch"),  # newest day, not yet populated
+    ]
+
+    kept = select(assets_of(items, suffixes=(".csv",)), latest_run=True)
+
+    assert [a.forecast_run for a in kept] == ["202607210600"]
+
+
+def test_latest_run_is_a_no_op_without_runs():
+    """Applied unconditionally to a non-forecast listing, it must change nothing."""
+    assets = assets_of([_item("ber", "ogd-smn_ber_d_recent.csv")], suffixes=(".csv",))
+
+    assert select(assets, latest_run=True) == assets
+
+
+def test_latest_run_of_reports_the_run():
+    items = [_item("d", "vnut12.lssw.202607210400.x.csv", "vnut12.lssw.202607210600.x.csv")]
+
+    assert latest_run_of(assets_of(items)) == "202607210600"
+    assert latest_run_of(assets_of([_item("ber", "ogd-smn_ber_d_recent.csv")])) is None
+
+
+def test_selection_composes():
+    """What load() does: slice, granularity and run in one pass."""
+    items = [_item("ber", "ogd-smn_ber_d_recent.csv", "ogd-smn_ber_t_recent.csv", "ogd-smn_ber_d_historical.csv")]
+
+    kept = select(assets_of(items, suffixes=(".csv",)), time_slices=["recent"], granularities=["d"])
+
+    assert [a.name for a in kept] == ["ogd-smn_ber_d_recent.csv"]
+
+
+def test_hrefs_returns_what_gets_fetched():
+    items = [_item("ber", "ogd-smn_ber_d_recent.csv")]
+
+    assert hrefs(assets_of(items)) == [f"{BASE}/ogd-smn_ber_d_recent.csv"]
+
+
+# --- collection-level assets ---------------------------------------------
+
+
+def test_collection_assets_match_by_name():
+    collection = {"assets": {"params": {"href": f"{BASE}/ogd-smn_meta_parameters.csv"}}}
+
+    (asset,) = collection_assets(collection, suffixes=(".csv",), contains="_meta_parameters")
+
+    assert asset.name == "ogd-smn_meta_parameters.csv"
+
+
+def test_collection_assets_match_by_key():
+    """The GRIB2 constants file is identified by its key, not its filename."""
+    collection = {
+        "assets": {
+            "horizontal_constants_icon-ch1-eps.grib2": {"href": f"{BASE}/hc.grib2"},
+            "params_icon-ch1-eps.csv": {"href": f"{BASE}/params.csv"},
+        }
+    }
+
+    (asset,) = collection_assets(collection, key_contains="horizontal_constants")
+
+    assert asset.name == "hc.grib2"
+
+
+def test_collection_with_no_assets_yields_nothing():
+    assert collection_assets({}, suffixes=(".csv",)) == []
+
+
+# --- shape ---------------------------------------------------------------
+
+
+def test_assets_are_hashable_and_comparable():
+    """Frozen, so callers can dedupe or diff listings without care."""
+    a, b = assets_of([_item("ber", "x.csv")]), assets_of([_item("ber", "x.csv")])
+
+    assert a == b
+    assert len({*a, *b}) == 1
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [("grid.nc", ".nc"), ("archive.ZIP", ".zip"), ("noext", "")],
+)
+def test_extension_is_normalised(name, expected):
+    (asset,) = assets_of([_item("i", name)])
+
+    assert asset.extension == expected
+
+
+def test_missing_href_does_not_blow_up():
+    """A malformed asset should be inert, not an AttributeError mid-listing."""
+    items = [{"id": "i", "properties": {}, "assets": {"broken": {}}}]
+
+    (asset,) = assets_of(items)
+
+    assert asset.href == ""
+    assert asset.name == ""
+
+
+def test_asset_from_stac_defaults():
+    asset = Asset.from_stac("k", {"href": f"{BASE}/ogd-smn_ber_d_now.csv"})
+
+    assert asset.key == "k"
+    assert asset.item_id == ""
+    assert asset.updated == ""
+    assert asset.time_slice == "now"


### PR DESCRIPTION
Candidate 3 from the architecture review — the last of the "Strong" ones.

## Why

`fetch` hands back raw STAC dicts, so every caller did the same three things itself: walk `item["assets"]`, strip the query string, and re-derive the time slice / granularity / forecast run from the filename. **Sixteen** hand-rolled walks across `client`, `api` and `grids`.

The forecast-run rule — collect the runs, take `max()`, keep only that one — was written out **twice**, in `client.download_collection` and `api.load`, comments included. The two had to stay in step for a download and a load to agree on which forecast you get.

## What

`src/foehn/assets.py`, sitting above the port:

```
Asset            href · name · key · updated · item_id
                 time_slice · granularity · forecast_run
assets_of(items, suffixes=, contains=, excludes=)   narrow by name
select(assets, time_slices=, granularities=, latest_run=)   narrow by meaning
collection_assets(coll, ..., key_contains=)   the collection's own assets
```

Per the grilling: a new module rather than the port, because a time slice is a MeteoSwiss fact and the transport shouldn't know it — and it carries the *selection*, not just the type, because the selection is what was duplicated. The filename parsers stay in `collections.py` with the rest of the naming rules; `granularity_from_filename` joins them, having been inline in `api.load`.

Callers pass `Asset`s rather than bare hrefs, so nothing downstream re-derives a filename from a string it was handed.

| | before | after |
|---|---|---|
| hand-rolled asset walks | 16 | 1 (inside `assets.py`) |
| forecast-run rule | 2 copies | 1 |
| `asset_filename`/`clean_href` in callers | 7 | 0 |

## Two behaviours worth checking in review

Both were implicit before and are now stated in one place, with a test each:

- **Time slice keeps unsliced assets.** A file with no slice segment is unsliced data every query includes — not data that matches nothing. (`select(..., time_slices=[...])`)
- **Granularity drops assets without one.** The opposite, and deliberately so: a file with no granularity segment cannot satisfy `frequency=`.

They differ, they always did, and previously you had to read two loops to see it.

## Verification

- 461 tests pass (up from 435); coverage 90.6% → 91.1%, `assets.py` at 100%, `api.py` 94% → 95%
- ruff, `ty`, both live tests clean
- Smoke-tested against the live API across all four selection paths: standard CSV (slice + granularity), forecast (latest run), collection-level metadata assets, and decade-split historical — the two trickiest rules included