### PR TITLE
Deepen the download, convert and load paths

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -107,8 +107,32 @@ _Avoid_: raw, landing (the Databricks ingest script's word for the same place)
 **Fetcher**:
 The module that owns every HTTP call foehn makes to MeteoSwiss: STAC listing and
 metadata, and file downloads. Retry policy, per-thread sessions, URL validation
-and pagination live behind it.
+and pagination live behind it. One call.
 _Avoid_: client, session, transport
+
+**Transfer**:
+The module that owns turning a set of **Assets** into files: the worker pool,
+destination de-duplication, per-asset failure isolation, ETag bookkeeping,
+atomic writes and the counts in a **Download result**. Many calls, where the
+**Fetcher** is one. Every download path goes through it.
+_Avoid_: downloader, batch, pool
+
+**Download result**:
+What a download reports: `total_assets`, `downloaded`, `skipped`, `failed` and
+the new filenames. The first is every **Asset** the call was given, and the
+other three sum to it.
+
+**Reader**:
+How one **Dataset kind** becomes a Polars DataFrame — one per tabular kind,
+selected from the registry exactly as its download and convert paths are.
+_Avoid_: loader, parser (parsing is one step inside a reader)
+
+**Filters**:
+One load query, normalised: stations and granularities lowercased, scalars
+widened to tuples, an empty list read as "no filter". The public `load()`
+keywords are packed into one of these at the seam, so nothing below restates
+the eleven arguments.
+_Avoid_: query, params, options
 
 ## Relationships
 
@@ -118,6 +142,8 @@ _Avoid_: client, session, transport
 - A **Standard CSV** **Asset** is identified by its station, **Granularity** and **Time slice**.
 - A **Forecast CSV** **Asset** is identified by its **Forecast run**.
 - Every network read of a **Collection**, **Item** or **Asset** goes through the **Fetcher**.
+- Every **Asset** written to **Bronze** goes through **Transfer**, which calls the **Fetcher**.
+- A **Dataset kind** has one download path, one convert path and (when tabular) one **Reader**.
 
 ## Flagged ambiguities
 
@@ -129,3 +155,7 @@ _Avoid_: client, session, transport
   is HDF5. Resolved: **Radar grid** is its own **Dataset kind**.
 - "Frequency" and "granularity" both refer to the aggregation interval. Resolved:
   the concept is **Granularity**; `frequency` survives only as a public parameter name.
+- The valid **Granularity** and **Time slice** tokens were listed twice — once in
+  `collections`, once again in the MCP layer, which could only agree or drift.
+  Resolved: `collections.GRANULARITIES` and `collections.TIME_SLICES` are the
+  vocabulary, `load()` enforces it, and the MCP tools restate nothing.

--- a/scripts/ingest_delta.py
+++ b/scripts/ingest_delta.py
@@ -31,7 +31,7 @@ import polars as pl
 from pyspark.sql import SparkSession
 
 from foehn import registry
-from foehn.convert import _load_metadata_types, group_csv_files, parse_csv_bytes
+from foehn.convert import group_csv_files, load_metadata_types, parse_csv_bytes
 
 TABULAR_COLLECTIONS = [*registry.tabular_datasets(), "climate_normals"]
 
@@ -56,7 +56,9 @@ def _table_suffix(group_key: tuple[str, ...]) -> str:
     return ""
 
 
-def _build_schema_overrides(files: list[Path], metadata_types: dict[str, pl.DataType]) -> dict[str, pl.DataType] | None:
+def _build_schema_overrides(
+    files: list[Path], metadata_types: dict[str, type[pl.DataType]]
+) -> dict[str, type[pl.DataType]] | None:
     """Match CSV column headers to metadata types for schema overrides."""
     if not metadata_types:
         return None
@@ -68,7 +70,7 @@ def _build_schema_overrides(files: list[Path], metadata_types: dict[str, pl.Data
         return None
 
 
-def _scan_and_collect(files: list[Path], metadata_types: dict[str, pl.DataType]) -> pl.DataFrame:
+def _scan_and_collect(files: list[Path], metadata_types: dict[str, type[pl.DataType]]) -> pl.DataFrame:
     """Lazily scan CSV files and collect with streaming engine.
 
     Falls back to eager parse_csv_bytes (with retry logic) if streaming
@@ -192,7 +194,7 @@ def _ingest_collection(
 
     Returns (succeeded, skipped) counts.
     """
-    metadata_types = _load_metadata_types(csv_dir)
+    metadata_types = load_metadata_types(csv_dir)
     groups = group_csv_files(csv_dir, key)
 
     meta_ok, meta_skip = _ingest_metadata(spark, key, csv_dir, catalog, schema)

--- a/src/foehn/_urls.py
+++ b/src/foehn/_urls.py
@@ -25,7 +25,7 @@ def validate_download_href(href: str) -> str:
     return _validate_https_url(href, DOWNLOAD_DOMAINS, "download")
 
 
-def clean_href(href: str) -> str:
+def _clean_href(href: str) -> str:
     """Return *href* without its query string.
 
     STAC asset hrefs may carry a query (``?token=...``), so every suffix or
@@ -37,4 +37,4 @@ def clean_href(href: str) -> str:
 
 def asset_filename(href: str) -> str:
     """Return just the filename of an asset href, ignoring any query string."""
-    return clean_href(href).rsplit("/", 1)[-1]
+    return _clean_href(href).rsplit("/", 1)[-1]

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -2,37 +2,27 @@
 
 from __future__ import annotations
 
-import re
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import polars as pl
 
 from foehn import registry
-from foehn._urls import asset_filename
-from foehn.assets import assets_of, collection_assets, hrefs, select
+from foehn.assets import collection_assets
 from foehn.client import (
     DownloadResult,
-    _check_zip_size,
 )
 from foehn.collections import (
     COLLECTION_META,
     COLLECTIONS,
-    DatasetKind,
-    kind,
+    GRANULARITIES,
+    TIME_SLICES,
 )
 from foehn.convert import (
-    _parse_metadata_types,
-    add_forecast_local_timestamp,
-    add_indoor_columns,
     decode_meteoswiss_csv,
-    parse_climate_scenarios_csv,
-    parse_csv_bytes,
-    parse_indoor_filename,
-    utf8_meteoswiss_csv,
 )
 from foehn.fetch import DEFAULT_WORKERS, default_fetcher
 from foehn.grids import open_dataset, to_zarr
+from foehn.readers import Filters, apply_time_filters
 
 __all__ = [
     "download",
@@ -227,10 +217,6 @@ def inventory(dataset: str) -> pl.DataFrame:
     )
 
 
-# A ``date_to`` of exactly "YYYY-MM-DD" names a whole day, not its midnight.
-_BARE_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-
-
 def _require_columns(df: pl.DataFrame, names: list[str], label: str) -> None:
     """Raise ValueError naming any of *names* the loaded frame doesn't have.
 
@@ -248,204 +234,30 @@ def _require_columns(df: pl.DataFrame, names: list[str], label: str) -> None:
     raise ValueError(f"Unknown column(s) {missing} in {label}=. This dataset has: {available}")
 
 
-def _apply_time_filters(
-    df: pl.DataFrame,
-    *,
-    year: int | list[int] | None = None,
-    month: int | list[int] | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
-) -> pl.DataFrame:
-    """Apply the timestamp row predicates shared by the post-filter and the per-frame pass.
-
-    Split out of :func:`_apply_post_filters` so ``load()`` can run it on each CSV
-    as it is parsed, instead of only on the concatenated result. These are all
-    per-row predicates, so filtering early is equivalent — but it bounds peak
-    memory by the largest single station file rather than by the whole matched
-    set. ``drop_null`` deliberately stays in the post-filter: a frame missing
-    that column keeps every row here, while after a diagonal concat the column
-    exists as null across those rows and they are dropped.
-    """
-    ts = "reference_timestamp"
-    if year is not None:
-        years = [year] if isinstance(year, int) else year
-        df = df.filter(pl.col(ts).dt.year().is_in(years))
-    if month is not None:
-        months = [month] if isinstance(month, int) else month
-        df = df.filter(pl.col(ts).dt.month().is_in(months))
-    # Cast the timestamp column to Datetime before comparing: some daily/monthly
-    # files parse ``reference_timestamp`` as a Date, and comparing Date vs the
-    # Datetime literal would raise. Date→Datetime and Datetime→Datetime are both safe.
-    if date_from is not None:
-        df = df.filter(pl.col(ts).cast(pl.Datetime) >= pl.lit(date_from).str.to_datetime())
-    if date_to is not None:
-        bound = pl.lit(date_to).str.to_datetime()
-        if _BARE_DATE_RE.match(date_to):
-            # A bare "YYYY-MM-DD" means the whole of that day. Comparing <= the
-            # parsed midnight is right for d/m/y (timestamps sit at 00:00) but
-            # silently drops every 10-minute and hourly reading after 00:00, so
-            # bound the day exclusively at the next midnight instead.
-            df = df.filter(pl.col(ts).cast(pl.Datetime) < bound.dt.offset_by("1d"))
-        else:
-            df = df.filter(pl.col(ts).cast(pl.Datetime) <= bound)
-    return df
-
-
-def _apply_post_filters(
-    df: pl.DataFrame,
-    dataset: str,
-    *,
-    year: int | list[int] | None = None,
-    month: int | list[int] | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
-    drop_null: str | None = None,
-    sort: str | None = None,
-    columns: list[str] | None = None,
-    limit: int | None = None,
-) -> pl.DataFrame:
-    """Apply the shared in-memory row/column filters used by load() variants.
+def _apply_post_filters(df: pl.DataFrame, dataset: str, filters: Filters) -> pl.DataFrame:
+    """Apply the row/column filters that are the same for every kind.
 
     Which columns an explicit ``columns=`` selection always keeps is a property of
     the dataset's kind, so it is read from the registry rather than passed in —
     callers were previously stating their own schema across this seam, and only
-    one of the three got it right for its kind.
+    one of the three got it right for its kind. Running this once here, after
+    whichever reader produced the frame, is what keeps the readers free of it.
     """
     spec = registry.spec(dataset)
-    df = _apply_time_filters(df, year=year, month=month, date_from=date_from, date_to=date_to)
-    if drop_null:
-        _require_columns(df, [drop_null], "drop_null")
-        df = df.filter(pl.col(drop_null).is_not_null())
-    if sort in ("asc", "desc"):
-        df = df.sort(spec.sort_column, descending=(sort == "desc"))
-    if columns:
-        _require_columns(df, columns, "columns")
+    df = apply_time_filters(df, filters)
+    if filters.drop_null:
+        _require_columns(df, [filters.drop_null], "drop_null")
+        df = df.filter(pl.col(filters.drop_null).is_not_null())
+    if filters.sort in ("asc", "desc"):
+        df = df.sort(spec.sort_column, descending=(filters.sort == "desc"))
+    if filters.columns:
+        _require_columns(df, list(filters.columns), "columns")
         keep = [c for c in spec.key_columns if c in df.columns]
-        keep += [c for c in columns if c not in keep]
+        keep += [c for c in filters.columns if c not in keep]
         df = df.select(keep)
-    if limit is not None:
-        df = df.head(limit)
+    if filters.limit is not None:
+        df = df.head(filters.limit)
     return df
-
-
-def _load_indoor(
-    dataset: str,
-    *,
-    station: str | list[str] | None = None,
-    year: int | list[int] | None = None,
-    month: int | list[int] | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
-    columns: list[str] | None = None,
-    drop_null: str | None = None,
-    sort: str | None = None,
-    limit: int | None = None,
-) -> pl.DataFrame:
-    """Load a zipped multi-CSV collection (indoor scenarios) into a DataFrame.
-
-    Unlike the per-station collections, this is a single archive, so the whole
-    ZIP is fetched and parsed in memory; ``station`` filters which member CSVs
-    are parsed, the rest of the filters apply to the combined frame.
-    """
-    import io
-    import zipfile
-
-    collection_id = COLLECTIONS[dataset]
-    fetcher = default_fetcher()
-    items = fetcher.items(collection_id)
-    archives = assets_of(items, suffixes=(".zip",))
-    if not archives:
-        raise ValueError(f"No .zip asset found for {dataset!r}.")
-    zip_href = archives[0].href
-
-    station_filter: set[str] | None = None
-    if station is not None:
-        station_filter = {station.lower()} if isinstance(station, str) else {s.lower() for s in station}
-
-    archive = fetcher.get(zip_href, timeout=300).body
-
-    frames: list[pl.DataFrame] = []
-    with zipfile.ZipFile(io.BytesIO(archive)) as zf:
-        # Everything below is parsed in memory — refuse a decompression bomb.
-        _check_zip_size(zf, zip_href.split("/")[-1])
-        for name in zf.namelist():
-            if not name.endswith(".csv"):
-                continue
-            parsed = parse_indoor_filename(Path(name).stem)
-            if parsed is None:
-                continue
-            st, period, scenario, variant = parsed
-            if station_filter is not None and st.lower() not in station_filter:
-                continue
-            with zf.open(name) as fh:
-                frame = pl.read_csv(fh.read(), separator=",", infer_schema_length=10_000, truncate_ragged_lines=True)
-            frames.append(add_indoor_columns(frame, st, period, scenario, variant))
-
-    if not frames:
-        raise ValueError(f"No indoor data found for {dataset!r} with station={station}.")
-
-    df = pl.concat(frames, how="diagonal_relaxed")
-    return _apply_post_filters(
-        df,
-        dataset,
-        year=year,
-        month=month,
-        date_from=date_from,
-        date_to=date_to,
-        drop_null=drop_null,
-        sort=sort,
-        columns=columns,
-        limit=limit,
-    )
-
-
-def _load_climate_scenarios(
-    dataset: str,
-    *,
-    station: str | list[str] | None = None,
-    columns: list[str] | None = None,
-    drop_null: str | None = None,
-    sort: str | None = None,
-    limit: int | None = None,
-    workers: int = DEFAULT_WORKERS,
-) -> pl.DataFrame:
-    """Load CH2025 climate-scenario CSVs (metadata preamble + wide model table).
-
-    Dates are nominal (0001..0030 on a 365-day calendar), so the calendar-based
-    year/month/date filters do not apply here; ``sort`` orders lexically by the
-    string ``date`` column.
-    """
-    collection_id = COLLECTIONS[dataset]
-    fetcher = default_fetcher()
-
-    station_filter: set[str] | None = None
-    if station is not None:
-        station_filter = {station.lower()} if isinstance(station, str) else {s.lower() for s in station}
-
-    items = fetcher.items(collection_id)
-    if station_filter is not None:
-        items = [item for item in items if item.get("id", "").lower() in station_filter]
-
-    csv_hrefs = hrefs(assets_of(items, suffixes=(".csv",), excludes="_meta_"))
-    if not csv_hrefs:
-        raise ValueError(f"No climate-scenario CSVs found for {dataset!r} with station={station}.")
-
-    # The fetcher is safe to share across the pool: it hands each worker thread
-    # its own session.
-    def _fetch(href: str) -> pl.DataFrame:
-        return parse_climate_scenarios_csv(fetcher.get(href, timeout=120).body, asset_filename(href))
-
-    if len(csv_hrefs) == 1 or workers <= 1:
-        frames = [_fetch(h) for h in csv_hrefs]
-    else:
-        with ThreadPoolExecutor(max_workers=workers) as pool:
-            frames = list(pool.map(_fetch, csv_hrefs))
-
-    df = pl.concat(frames, how="diagonal_relaxed")
-    # The calendar filters are rejected for this kind before we get here, so the
-    # shared pass's time filtering is a no-op and only the column/sort/limit half
-    # applies — which is why this can use it rather than repeating it.
-    return _apply_post_filters(df, dataset, drop_null=drop_null, sort=sort, columns=columns, limit=limit)
 
 
 def load(
@@ -529,152 +341,36 @@ def load(
         raise ValueError(f"Dataset {dataset!r} is a binary/grid dataset and cannot be loaded as a DataFrame.")
     if frequency is not None and not spec.supports_granularity:
         raise ValueError(f"Dataset {dataset!r} does not support frequency filtering.")
-    if not spec.supports_calendar_filters and any(x is not None for x in (year, month, date_from, date_to)):
+    if sort is not None and sort not in ("asc", "desc"):
+        raise ValueError(f"Invalid sort {sort!r}. Valid options: asc, desc.")
+
+    filters = Filters.build(
+        station=station,
+        frequency=frequency,
+        time_slice=time_slice,
+        year=year,
+        month=month,
+        date_from=date_from,
+        date_to=date_to,
+        columns=columns,
+        drop_null=drop_null,
+        sort=sort,
+        limit=limit,
+        workers=workers,
+    )
+    # Reject a token outside the vocabulary rather than quietly matching no
+    # assets and reporting "no CSV files found" — a mistyped frequency is a
+    # caller error, and the MCP layer used to catch it with its own copy of
+    # these two sets.
+    if filters.granularities and (unknown := sorted(filters.granularities - GRANULARITIES)):
+        raise ValueError(f"Invalid frequency {unknown}. Valid options: {', '.join(sorted(GRANULARITIES))}.")
+    if unknown_slices := sorted(set(filters.time_slices) - TIME_SLICES):
+        raise ValueError(f"Invalid time_slice {unknown_slices}. Valid options: {', '.join(sorted(TIME_SLICES))}.")
+    if not spec.supports_calendar_filters and filters.has_calendar_filter:
         raise ValueError(
             f"Dataset {dataset!r} uses nominal 30-year dates (0001..0030); "
             "year/month/date_from/date_to filters are not supported."
         )
 
-    if kind(dataset) is DatasetKind.ARCHIVE_CSV:
-        return _load_indoor(
-            dataset,
-            station=station,
-            year=year,
-            month=month,
-            date_from=date_from,
-            date_to=date_to,
-            columns=columns,
-            drop_null=drop_null,
-            sort=sort,
-            limit=limit,
-        )
-
-    if kind(dataset) is DatasetKind.PREAMBLE_CSV:
-        return _load_climate_scenarios(
-            dataset,
-            station=station,
-            columns=columns,
-            drop_null=drop_null,
-            sort=sort,
-            limit=limit,
-            workers=workers,
-        )
-
-    if time_slice is None:
-        time_slice = ["recent"]
-    elif isinstance(time_slice, str):
-        time_slice = [time_slice]
-
-    # Normalise station filter to a set of lowercase abbreviations. An empty list
-    # means "no filter", not "match nothing" — the latter is never what a caller
-    # wants, and the MCP layer used to strip empty lists on load()'s behalf.
-    station_filter: set[str] | None = None
-    if station:
-        if isinstance(station, str):
-            station_filter = {station.lower()}
-        else:
-            station_filter = {s.lower() for s in station}
-
-    # Normalise frequency filter to a set (e.g. {"d", "h"}).
-    freq_filter: set[str] | None = None
-    if frequency:
-        if isinstance(frequency, str):
-            freq_filter = {frequency.lower()}
-        else:
-            freq_filter = {f.lower() for f in frequency}
-
-    collection_id = COLLECTIONS[dataset]
-    fetcher = default_fetcher()
-
-    # 1. Fetch metadata types for schema inference.
-    metadata_types: dict[str, type[pl.DataType]] = {}
-    coll = fetcher.collection(collection_id)
-    for asset in collection_assets(coll, suffixes=(".csv",), contains="_meta_parameters"):
-        metadata_types = _parse_metadata_types(decode_meteoswiss_csv(fetcher.get(asset.href, timeout=60).body))
-        break
-
-    # 2. Get STAC items and collect matching CSV URLs.
-    items = fetcher.items(collection_id)
-
-    # Filter items by station (item id = station abbreviation).
-    if station_filter is not None:
-        items = [item for item in items if item.get("id", "").lower() in station_filter]
-
-    # A forecast item is one *day*, not one forecast, and the newest one is empty
-    # until that day's runs publish — so keep all items and narrow to the newest
-    # run by filename below. Ranking on ``datetime`` would not help either: it is a
-    # refresh timestamp, identical across items to the microsecond.
-    if kind(dataset) is DatasetKind.FORECAST_CSV and items:
-        items.sort(key=lambda x: x.get("id", ""))
-
-    # Forecast filenames carry no time slice; load() wants the current forecast,
-    # so narrowing to the newest run is what bounds them instead.
-    is_forecast = kind(dataset) is DatasetKind.FORECAST_CSV
-    csv_hrefs = hrefs(
-        select(
-            assets_of(items, suffixes=(".csv",)),
-            time_slices=None if is_forecast else time_slice,
-            granularities=freq_filter,
-            latest_run=is_forecast,
-        )
-    )
-
-    if not csv_hrefs:
-        filters = f"station={station}, frequency={frequency}, time_slice={time_slice}"
-        raise ValueError(f"No CSV files found for {dataset!r} with {filters}.")
-
-    # 3. Download and parse each CSV concurrently. The fetcher is safe to share
-    # across the pool: it hands each worker thread its own session.
-    # With an explicit ``columns=``, tell the parser up front instead of parsing all
-    # ~42 columns of every station file and selecting afterwards. The frame retained
-    # per station drops by an order of magnitude, which is what bounds peak memory
-    # while the whole matched set is assembled. Everything the later filters and the
-    # concat rely on has to survive the projection.
-    wanted_columns: set[str] | None = None
-    if columns:
-        wanted_columns = {"station_abbr", "reference_timestamp", *columns}
-        if drop_null:
-            wanted_columns.add(drop_null)
-        if dataset == "forecast_local":
-            wanted_columns.add("Date")  # reference_timestamp is derived from it
-
-    def _fetch(href: str) -> pl.DataFrame:
-        # Zero-copy when the payload is already UTF-8 (the usual case): these are
-        # the big files, and ``workers`` of them are in flight at once.
-        body = fetcher.get(href, timeout=60).body
-        frame = parse_csv_bytes(utf8_meteoswiss_csv(body), metadata_types, wanted_columns=wanted_columns)
-        # Drop the rows this call can never return *before* they reach the
-        # concat. Every frame is otherwise held in full until the whole matched
-        # set is materialised, so a narrow year= over many stations peaked at the
-        # size of the entire time slice. forecast_local has no reference_timestamp
-        # of its own — derive it here so its frames can be narrowed too.
-        if dataset == "forecast_local":
-            frame = add_forecast_local_timestamp(frame)
-        if "reference_timestamp" in frame.columns:
-            frame = _apply_time_filters(frame, year=year, month=month, date_from=date_from, date_to=date_to)
-        return frame
-
-    if len(csv_hrefs) == 1 or workers <= 1:
-        frames = [_fetch(href) for href in csv_hrefs]
-    else:
-        with ThreadPoolExecutor(max_workers=workers) as pool:
-            frames = list(pool.map(_fetch, csv_hrefs))
-
-    df = pl.concat(frames, how="diagonal_relaxed")
-
-    # forecast_local has no reference_timestamp; derive it from the compact Date column.
-    if dataset == "forecast_local":
-        df = add_forecast_local_timestamp(df)
-
-    return _apply_post_filters(
-        df,
-        dataset,
-        year=year,
-        month=month,
-        date_from=date_from,
-        date_to=date_to,
-        drop_null=drop_null,
-        sort=sort,
-        columns=columns,
-        limit=limit,
-    )
+    df = registry.load(dataset, filters, fetcher=default_fetcher())
+    return _apply_post_filters(df, dataset, filters)

--- a/src/foehn/cli.py
+++ b/src/foehn/cli.py
@@ -21,7 +21,7 @@ from foehn.collections import COLLECTIONS
 from foehn.convert import (
     convert_climate_normals_to_parquet,
 )
-from foehn.fetch import default_fetcher
+from foehn.fetch import DEFAULT_WORKERS, default_fetcher
 
 
 def _resolve_data_dir(args_data_dir: Path | None) -> Path:
@@ -273,33 +273,24 @@ def cmd_mcp(args: argparse.Namespace) -> None:
 def cmd_load(args: argparse.Namespace) -> None:
     from foehn.api import load
 
-    kwargs: dict = {}
-    if args.station:
-        kwargs["station"] = args.station
-    if args.frequency:
-        kwargs["frequency"] = args.frequency
-    if args.time_slice:
-        kwargs["time_slice"] = args.time_slice
-    if args.year:
-        kwargs["year"] = args.year
-    if args.month:
-        kwargs["month"] = args.month
-    if args.date_from:
-        kwargs["date_from"] = args.date_from
-    if args.date_to:
-        kwargs["date_to"] = args.date_to
-    if args.columns:
-        kwargs["columns"] = args.columns
-    if args.drop_null:
-        kwargs["drop_null"] = args.drop_null
-    if args.sort:
-        kwargs["sort"] = args.sort
-    if args.limit is not None:
-        kwargs["limit"] = args.limit
-    if args.workers is not None:
-        kwargs["workers"] = args.workers
-
-    df = load(args.dataset, **kwargs)
+    # argparse leaves every unset option as None, which is what load() already
+    # treats as "no filter" — so the options go straight across. ``workers`` is
+    # the one exception: its default is a count, not None.
+    df = load(
+        args.dataset,
+        station=args.station,
+        frequency=args.frequency,
+        time_slice=args.time_slice,
+        year=args.year,
+        month=args.month,
+        date_from=args.date_from,
+        date_to=args.date_to,
+        columns=args.columns,
+        drop_null=args.drop_null,
+        sort=args.sort,
+        limit=args.limit,
+        workers=args.workers if args.workers is not None else DEFAULT_WORKERS,
+    )
 
     n = args.n or 20
     print(df.head(n))

--- a/src/foehn/client.py
+++ b/src/foehn/client.py
@@ -5,79 +5,29 @@ from __future__ import annotations
 import json
 import logging
 import zipfile
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-from foehn.assets import assets_of, collection_assets, latest_run_of, select
+from foehn.assets import Asset, assets_of, collection_assets, latest_run_of, select
 from foehn.collections import (
     CLIMATE_NORMALS_ZIP_URL,
     COLLECTIONS,
     DatasetKind,
     kind,
 )
-from foehn.convert import utf8_meteoswiss_csv
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
+from foehn.transfer import (
+    DownloadResult,
+    atomic_write_text,
+    csv_to_disk,
+    fetch_all,
+    stream_to_disk,
+)
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class DownloadResult:
-    """Summary of a download call. Returned by all download_* functions.
-
-    Callers use this to decide whether to run expensive downstream work
-    (e.g. Spark MERGE INTO) without scanning the output directory.
-
-    ``total_assets`` is per-producer: ``download_collection`` counts the assets
-    left after its time-slice filter, while ``download_grib2``/``download_netcdf``
-    count every matching asset in the listing. ``foehn.download`` sums results
-    across the metadata and data passes, so treat the total as a scale hint
-    rather than a figure comparable between dataset types.
-    """
-
-    total_assets: int = 0
-    downloaded: int = 0
-    skipped: int = 0
-    failed: int = 0
-    filenames: list[str] = field(default_factory=list)
-
-
-def _dedupe_by_destination(pairs: list[tuple[str, Path]]) -> list[tuple[str, Path]]:
-    """Keep one (href, filepath) pair per destination path.
-
-    Two hrefs resolving to the same local filename would have workers streaming
-    into the same ``.part`` file at once and corrupting it. A collision is an
-    upstream naming quirk we can't resolve here, so keep the first and say so
-    rather than dropping one silently.
-    """
-    seen: dict[Path, str] = {}
-    for href, filepath in pairs:
-        if filepath in seen:
-            logger.warning("  Duplicate destination %s — skipping %s", filepath.name, href)
-            continue
-        seen[filepath] = href
-    return [(href, filepath) for filepath, href in seen.items()]
-
-
 # --- State files (ETags + last-run timestamp) ---
-
-
-def _atomic_write_text(path: Path, text: str) -> None:
-    """Write text via a sibling temp file + Path.replace so readers never see a torn write."""
-    _atomic_write_bytes(path, text.encode("utf-8"))
-
-
-def _atomic_write_bytes(path: Path, data: bytes | memoryview) -> None:
-    """Write bytes via a sibling temp file + Path.replace so readers never see a torn write."""
-    tmp = path.with_name(path.name + ".tmp")
-    try:
-        tmp.write_bytes(data)
-        tmp.replace(path)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
 
 
 def load_etags(data_dir: Path) -> dict:
@@ -93,7 +43,7 @@ def load_etags(data_dir: Path) -> dict:
 def save_etags(data_dir: Path, etags: dict):
     path = data_dir / "_etags.json"
     path.parent.mkdir(parents=True, exist_ok=True)
-    _atomic_write_text(path, json.dumps(etags, indent=2))
+    atomic_write_text(path, json.dumps(etags, indent=2))
 
 
 def load_last_run(data_dir: Path) -> str | None:
@@ -112,34 +62,10 @@ def load_last_run(data_dir: Path) -> str | None:
 def save_last_run(data_dir: Path):
     path = data_dir / "_last_run.json"
     path.parent.mkdir(parents=True, exist_ok=True)
-    _atomic_write_text(path, json.dumps({"timestamp": datetime.now(UTC).isoformat()}))
+    atomic_write_text(path, json.dumps({"timestamp": datetime.now(UTC).isoformat()}))
 
 
 # --- CSV downloads ---
-
-
-def _download_csv(
-    fetcher: Fetcher,
-    href: str,
-    filepath: Path,
-    old_etag: str | None,
-) -> tuple[str, str, str, str | None]:
-    """Fetch a single CSV, re-encode to UTF-8, and write it to disk.
-
-    Returns (status, href, filename, new_etag) where status is "downloaded" or "skipped".
-    Only sends the stored ETag when the local file is still there — otherwise a
-    304 would report "skipped" over a file that no longer exists.
-    """
-    filename = filepath.name
-    etag = old_etag if old_etag and filepath.exists() else None
-    fetched = fetcher.get(href, etag=etag, timeout=60)
-    if fetched.not_modified:
-        return ("skipped", href, filename, None)
-    # MeteoSwiss CSVs are usually UTF-8 but some are Windows-1252; normalise to UTF-8.
-    # Bytes in, bytes out — decoding to str here only to re-encode on write would
-    # hold three copies of a multi-hundred-MB CSV at once, times ``workers``.
-    _atomic_write_bytes(filepath, utf8_meteoswiss_csv(fetched.body))
-    return ("downloaded", href, filename, fetched.etag)
 
 
 def download_collection(
@@ -174,7 +100,6 @@ def download_collection(
 
     collection_id = COLLECTIONS[collection_key]
     out_dir = output_dir / collection_key
-    out_dir.mkdir(parents=True, exist_ok=True)
 
     etags = load_etags(state_dir)
 
@@ -219,49 +144,23 @@ def download_collection(
         available = len({a.forecast_run for a in every_csv if a.forecast_run is not None})
         logger.info("  Latest forecast run: %s (of %d available)", run, available)
 
-    logger.info("  %d CSV files to process", len(csv_assets))
-
-    def _do_csv(href: str, filepath: Path, etag: str | None) -> tuple[str, str, str, str | None]:
-        return _download_csv(fetcher, href, filepath, etag)
-
-    total = len(csv_assets)
-    downloaded = 0
-    skipped = 0
-    failed = 0
-    filenames: list[str] = []
-    fetch_targets = _dedupe_by_destination([(a.href, out_dir / a.name) for a in csv_assets])
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        future_to_href = {
-            pool.submit(_do_csv, href, filepath, etags.get(href)): href for href, filepath in fetch_targets
-        }
-        for i, fut in enumerate(as_completed(future_to_href), 1):
-            # Isolate per-asset failures: one transient 404/timeout must not abort
-            # the batch (and discard the ETags collected from the other assets).
-            try:
-                status, href, filename, new_etag = fut.result()
-            except Exception as exc:
-                failed += 1
-                logger.warning("  [%d/%d] FAILED: %s — %s", i, total, future_to_href[fut], exc)
-                continue
-            if status == "skipped":
-                skipped += 1
-                continue
-            if new_etag:
-                etags[href] = new_etag
-            else:
-                # Server returned 200 without an ETag. Keeping the old one would
-                # re-send it as If-None-Match forever, so this asset would
-                # re-download every run and never once be skipped.
-                etags.pop(href, None)
-            downloaded += 1
-            filenames.append(filename)
-            logger.info("  [%d/%d] Downloaded: %s", i, total, filename)
+    # The conditional-GET writer decides "unchanged" from the server's 304, so
+    # there is no local skip rule here — the ETag store is the skip rule.
+    result = fetch_all(
+        csv_assets,
+        out_dir,
+        fetcher=fetcher,
+        workers=workers,
+        write=csv_to_disk,
+        etags=etags,
+        label="CSV",
+    )
 
     # Prune ETags for assets that no longer exist upstream, so _etags.json
     # doesn't grow forever (e.g. forecast runs get fresh filenames each cycle).
     # Only on a clean full listing: with ``since`` the item list is partial, and
     # after failures the universe may be incomplete.
-    if since is None and failed == 0:
+    if since is None and result.failed == 0:
         prefix = f"/{collection_id}/"
         listed = {a.href for a in every_csv}
         stale = [k for k in etags if prefix in k and k not in listed]
@@ -271,15 +170,7 @@ def download_collection(
             logger.info("  Pruned %d stale ETag entries", len(stale))
 
     save_etags(state_dir, etags)
-    if skipped:
-        logger.info("  Skipped %d unchanged files", skipped)
-    if failed:
-        logger.warning("  %d file(s) failed to download", failed)
-    logger.info("  Done — %d files downloaded", downloaded)
-
-    return DownloadResult(
-        total_assets=total, downloaded=downloaded, skipped=skipped, failed=failed, filenames=filenames
-    )
+    return result
 
 
 # --- Metadata downloads ---
@@ -289,47 +180,22 @@ def download_metadata(
     collection_key: str, output_dir: Path, workers: int = DEFAULT_WORKERS, *, fetcher: Fetcher
 ) -> DownloadResult:
     """Download collection-level metadata files (stations, parameters, inventory)."""
-    collection_id = COLLECTIONS[collection_key]
-    out_dir = output_dir / collection_key
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    coll = fetcher.collection(collection_id)
-    targets = _dedupe_by_destination([(a.href, out_dir / a.name) for a in collection_assets(coll, suffixes=(".csv",))])
-    if not targets:
-        return DownloadResult()
-
-    def _do_csv(href: str, filepath: Path) -> tuple[str, str, str, str | None]:
-        return _download_csv(fetcher, href, filepath, None)
-
-    downloaded = 0
-    failed = 0
-    filenames: list[str] = []
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        future_to_href = {pool.submit(_do_csv, href, filepath): href for href, filepath in targets}
-        for fut in as_completed(future_to_href):
-            try:
-                filename = fut.result()[2]
-            except Exception as exc:
-                failed += 1
-                logger.warning("  Metadata FAILED: %s — %s", future_to_href[fut], exc)
-                continue
-            downloaded += 1
-            filenames.append(filename)
-            logger.info("  Metadata: %s", filename)
-
-    if downloaded:
-        logger.info("  %d metadata files downloaded", downloaded)
-    if failed:
-        logger.warning("  %d metadata file(s) failed to download", failed)
-
-    return DownloadResult(total_assets=len(targets), downloaded=downloaded, failed=failed, filenames=filenames)
+    coll = fetcher.collection(COLLECTIONS[collection_key])
+    return fetch_all(
+        collection_assets(coll, suffixes=(".csv",)),
+        output_dir / collection_key,
+        fetcher=fetcher,
+        workers=workers,
+        write=csv_to_disk,
+        label="metadata file",
+    )
 
 
 # --- GRIB2 / HDF5 downloads ---
 
 
-def _needs_redownload(filepath: Path, remote_updated: str) -> bool:
-    """Decide whether to (re)download a binary asset.
+def _already_current(asset: Asset, filepath: Path) -> bool:
+    """A :data:`~foehn.transfer.SkipRule`: is the local copy of *asset* up to date?
 
     Handles MeteoSwiss's in-place overwrites — e.g. CombiPrecip reanalysis
     (CPCH) replaces the original CPC hourly file with the same filename
@@ -338,15 +204,20 @@ def _needs_redownload(filepath: Path, remote_updated: str) -> bool:
     picks up those server-side updates.
     """
     if not filepath.exists():
-        return True
-    if not remote_updated:
         return False
+    if not asset.updated:
+        return True
     try:
-        remote_dt = datetime.fromisoformat(remote_updated)
+        remote_dt = datetime.fromisoformat(asset.updated)
         local_dt = datetime.fromtimestamp(filepath.stat().st_mtime, tz=UTC)
     except (ValueError, OSError):
-        return False
-    return remote_dt > local_dt
+        return True
+    return remote_dt <= local_dt
+
+
+def _exists(_asset: Asset, filepath: Path) -> bool:
+    """A :data:`~foehn.transfer.SkipRule` for static assets: fetch each one once."""
+    return filepath.exists()
 
 
 def download_grib2(
@@ -359,12 +230,10 @@ def download_grib2(
 ) -> DownloadResult:
     """Download GRIB2/HDF5 binary files (latest page only)."""
     collection_id = COLLECTIONS[collection_key]
-    out_dir = output_dir / collection_key
-    out_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("%s", "=" * 60)
     logger.info("GRIB2 Collection: %s", collection_id)
-    logger.info("Output dir: %s", out_dir)
+    logger.info("Output dir: %s", output_dir / collection_key)
     logger.info("%s", "=" * 60)
 
     # Only the newest page — forecast/radar data is ephemeral and these
@@ -379,44 +248,14 @@ def download_grib2(
             logger.info("  Nothing changed — skipping")
             return DownloadResult()
 
-    binary_assets = assets_of(items, suffixes=(".grib2", ".h5", ".hdf5"))
-    logger.info("  %d binary files to download", len(binary_assets))
-
-    to_fetch = _dedupe_by_destination(
-        [(a.href, out_dir / a.name) for a in binary_assets if _needs_redownload(out_dir / a.name, a.updated)]
-    )
-
-    def _do_binary(href: str, filepath: Path) -> str:
-        fetcher.stream(href, filepath)
-        return filepath.name
-
-    total = len(to_fetch)
-    downloaded = 0
-    failed = 0
-    filenames: list[str] = []
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        future_to_href = {pool.submit(_do_binary, href, filepath): href for href, filepath in to_fetch}
-        for i, fut in enumerate(as_completed(future_to_href), 1):
-            try:
-                filename = fut.result()
-            except Exception as exc:
-                failed += 1
-                logger.warning("  [%d/%d] FAILED: %s — %s", i, total, future_to_href[fut], exc)
-                continue
-            downloaded += 1
-            filenames.append(filename)
-            logger.info("  [%d/%d] Downloaded: %s", i, total, filename)
-
-    if failed:
-        logger.warning("  %d binary file(s) failed to download", failed)
-    logger.info("  Done — %d binary files downloaded", downloaded)
-
-    return DownloadResult(
-        total_assets=len(binary_assets),
-        downloaded=downloaded,
-        skipped=len(binary_assets) - total,
-        failed=failed,
-        filenames=filenames,
+    return fetch_all(
+        assets_of(items, suffixes=(".grib2", ".h5", ".hdf5")),
+        output_dir / collection_key,
+        fetcher=fetcher,
+        workers=workers,
+        write=stream_to_disk,
+        skip=_already_current,
+        label="binary file",
     )
 
 
@@ -440,12 +279,10 @@ def download_netcdf(
         workers: Number of concurrent HTTP downloads.
     """
     collection_id = COLLECTIONS[collection_key]
-    out_dir = output_dir / collection_key
-    out_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("%s", "=" * 60)
     logger.info("NetCDF Collection: %s", collection_id)
-    logger.info("Output dir: %s", out_dir)
+    logger.info("Output dir: %s", output_dir / collection_key)
     logger.info("%s", "=" * 60)
 
     items = fetcher.items(collection_id)
@@ -458,42 +295,17 @@ def download_netcdf(
             logger.info("  Nothing changed — skipping")
             return DownloadResult()
 
-    spatial = assets_of(items, suffixes=(".nc", ".tif", ".zip"))
-    total_assets = len(spatial)
-    targets = _dedupe_by_destination([(a.href, out_dir / a.name) for a in spatial if not (out_dir / a.name).exists()])
-
-    def _do_binary(href: str, filepath: Path) -> str:
-        fetcher.stream(href, filepath)
-        return filepath.name
-
-    downloaded = 0
-    failed = 0
-    filenames: list[str] = []
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        future_to_href = {pool.submit(_do_binary, href, filepath): href for href, filepath in targets}
-        for fut in as_completed(future_to_href):
-            try:
-                filename = fut.result()
-            except Exception as exc:
-                failed += 1
-                logger.warning("  FAILED: %s — %s", future_to_href[fut], exc)
-                continue
-            downloaded += 1
-            filenames.append(filename)
-            logger.info("  Downloaded: %s", filename)
-
-    if failed:
-        logger.warning("  %d file(s) failed to download", failed)
-    logger.info("  Done — %d files downloaded", downloaded)
-
-    # ``skipped`` is the count of pre-existing files left untouched (total assets
-    # minus the ones we queued); failures are tracked separately in ``failed``.
-    return DownloadResult(
-        total_assets=total_assets,
-        downloaded=downloaded,
-        skipped=total_assets - len(targets),
-        failed=failed,
-        filenames=filenames,
+    # These are static: an existing file is never restated upstream, so a plain
+    # existence check is enough (unlike the ephemeral GRIB2/radar collections,
+    # which MeteoSwiss overwrites in place).
+    return fetch_all(
+        assets_of(items, suffixes=(".nc", ".tif", ".zip")),
+        output_dir / collection_key,
+        fetcher=fetcher,
+        workers=workers,
+        write=stream_to_disk,
+        skip=_exists,
+        label="file",
     )
 
 
@@ -507,8 +319,13 @@ def download_netcdf(
 _MAX_ZIP_EXTRACT_BYTES = 10 * 1024**3  # 10 GiB
 
 
-def _check_zip_size(zf: zipfile.ZipFile, source: str) -> None:
-    """Raise ValueError if the archive declares more decompressed bytes than the cap."""
+def check_zip_size(zf: zipfile.ZipFile, source: str) -> None:
+    """Raise ValueError if the archive declares more decompressed bytes than the cap.
+
+    Public because the archive *load* path reads its ZIP in memory rather than
+    through :func:`_safe_extract_zip`, and has to apply the same cap. One rule,
+    one place — the reader crossing this seam is part of the interface.
+    """
     total = sum(m.file_size for m in zf.infolist())
     if total > _MAX_ZIP_EXTRACT_BYTES:
         raise ValueError(
@@ -520,7 +337,7 @@ def _check_zip_size(zf: zipfile.ZipFile, source: str) -> None:
 def _safe_extract_zip(zip_path: Path, out_dir: Path) -> int:
     """Extract a ZIP after validating total size and member paths. Returns member count."""
     with zipfile.ZipFile(zip_path, "r") as zf:
-        _check_zip_size(zf, zip_path.name)
+        check_zip_size(zf, zip_path.name)
         resolved_out_dir = out_dir.resolve()
         for member in zf.infolist():
             target = (resolved_out_dir / member.filename).resolve()

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -466,6 +466,12 @@ CLIMATE_NORMALS_ZIP_URL = "https://data.geo.admin.ch/ch.meteoschweiz.klima/normw
 # CSV assets (ogd-{key}_{station}_{granularity}_{timeslice}.csv).
 TIME_SLICES = frozenset({"historical", "recent", "now"})
 
+# The granularity segment's vocabulary — the ``_t``/``_h``/``_d``/``_m``/``_y``
+# documented at the top of this module. Which of them a given dataset actually
+# has is ``COLLECTION_META[...]["frequencies"]``; this is the whole alphabet, and
+# the single source for it (the MCP layer used to carry its own copy).
+GRANULARITIES = frozenset({"t", "h", "d", "m", "y"})
+
 
 # MeteoSwiss chunks the high-frequency historical series by decade, so the slice
 # is not always the trailing segment: ``ogd-smn_ber_t_historical_2000-2009.csv``.

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -6,10 +6,14 @@ import codecs
 import io
 import logging
 import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 import polars as pl
+
+from foehn.collections import COLLECTIONS, NO_GRANULARITY_KINDS, kind
 
 logger = logging.getLogger(__name__)
 
@@ -77,11 +81,15 @@ _DTYPE_MAP: dict[str, type[pl.DataType]] = {
 }
 
 
-def _parse_metadata_types(content: bytes | str) -> dict[str, type[pl.DataType]]:
+def parse_metadata_types(content: bytes | str) -> dict[str, type[pl.DataType]]:
     """Build a parameter→Polars dtype mapping from metadata CSV content.
 
     Works with both raw bytes (in-memory) and string content.
     Returns an empty dict if the expected columns are missing.
+
+    Public because the in-memory load path crosses this seam for it: schema
+    inference from a collection's ``_meta_parameters.csv`` is one rule, and a
+    name-mangled import was hiding that it is part of this module's interface.
     """
     try:
         if isinstance(content, str):
@@ -103,11 +111,14 @@ def _parse_metadata_types(content: bytes | str) -> dict[str, type[pl.DataType]]:
     return type_map
 
 
-def _load_metadata_types(csv_dir: Path) -> dict[str, type[pl.DataType]]:
+def load_metadata_types(csv_dir: Path) -> dict[str, type[pl.DataType]]:
     """Build a parameter→Polars dtype mapping from a *_meta_parameters.csv file.
 
     Returns an empty dict if no metadata file is found or if the expected
     columns (``parameter_shortname``, ``parameter_datatype``) are missing.
+
+    The file-based counterpart to :func:`parse_metadata_types`, and public for
+    the same reason: the Databricks ingest script reads it across this seam.
     """
     # sorted(): glob order is filesystem-dependent, so an unsorted [0] picks
     # arbitrarily when a collection ships more than one metadata file.
@@ -117,7 +128,7 @@ def _load_metadata_types(csv_dir: Path) -> dict[str, type[pl.DataType]]:
 
     meta_path = meta_files[0]
     try:
-        return _parse_metadata_types(meta_path.read_bytes())
+        return parse_metadata_types(meta_path.read_bytes())
     except Exception:
         return {}
 
@@ -241,6 +252,68 @@ def _write_parquet_atomic(
         raise
 
 
+@dataclass(frozen=True)
+class ConversionGroup:
+    """One Parquet output and the source files it is built from."""
+
+    out_path: Path
+    sources: list[Path]
+
+
+ConvertOne = Callable[[ConversionGroup], int]
+"""Build ``group.out_path`` from ``group.sources``; return source-level failures tolerated.
+
+A converter that skips an unreadable source file and writes the rest reports how
+many it skipped, so the caller's exit code still reflects them. Raising instead
+means the whole group failed.
+"""
+
+
+def _is_up_to_date(group: ConversionGroup) -> bool:
+    """True when the output exists and is at least as new as every source."""
+    if not group.out_path.exists():
+        return False
+    out_mtime = group.out_path.stat().st_mtime
+    return all(f.stat().st_mtime <= out_mtime for f in group.sources)
+
+
+def run_conversions(groups: Iterable[ConversionGroup], convert_one: ConvertOne, *, label: str) -> int:
+    """Run each group's conversion, skipping outputs that are already current.
+
+    The four converters below each used to carry their own copy of this: the
+    mtime up-to-date check, the converted/skipped/failed counters, the per-group
+    try/except and the summary line. What actually differs between them is how a
+    frame is built — which is ``convert_one``, and stays with each kind.
+
+    Returns:
+        Total failures: groups that raised, plus the source-level failures the
+        conversions themselves reported. Zero means everything succeeded, which
+        is what gates ``_last_run.json``.
+    """
+    groups = list(groups)
+    if not groups:
+        return 0
+
+    logger.info("Converting %s to Parquet:", label)
+    converted = skipped = failed = 0
+    for group in sorted(groups, key=lambda g: g.out_path.name):
+        if _is_up_to_date(group):
+            skipped += 1
+            continue
+        group.out_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            failed += convert_one(group)
+        except Exception as e:
+            failed += 1
+            logger.warning("  %s (%d files)... FAIL: %s", group.out_path.name, len(group.sources), e)
+            continue
+        if group.out_path.exists():
+            converted += 1
+
+    logger.info("  Done: %d converted, %d skipped (up-to-date), %d failed", converted, skipped, failed)
+    return failed
+
+
 def add_forecast_local_timestamp(frame):
     """Add a parsed reference_timestamp from forecast_local's compact Date column.
 
@@ -270,8 +343,6 @@ def group_csv_files(csv_dir: Path, collection_key: str) -> dict[tuple[str, ...],
     must agree with the Parquet converter on where the boundaries are — these
     are upstream naming rules, and two copies of them drift.
     """
-    from foehn.collections import COLLECTIONS, NO_GRANULARITY_KINDS, kind
-
     csv_files = [f for f in sorted(csv_dir.glob("*.csv")) if "_meta_" not in f.name]
     groups: dict[tuple[str, ...], list[Path]] = {}
 
@@ -297,6 +368,63 @@ def group_csv_files(csv_dir: Path, collection_key: str) -> dict[tuple[str, ...],
     return groups
 
 
+def _group_out_name(collection_key: str, group_key: tuple[str, ...]) -> str:
+    """Output name for one group: smn_d_recent.parquet, smn_d.parquet, or smn.parquet."""
+    return f"{collection_key}_{'_'.join(group_key)}.parquet" if group_key else f"{collection_key}.parquet"
+
+
+def _convert_standard_group(collection_key: str, metadata_types: dict[str, type[pl.DataType]]) -> ConvertOne:
+    """Build the per-group converter for standard CSV collections.
+
+    Stays streaming the whole way: on dtype-drift errors (Int inferred from the
+    first N rows but a later row carries a decimal), parse the column name out of
+    the polars error, force it to Float64, and retry. RSS stays bounded — the
+    alternative of materialising every CSV blew up the driver on historical
+    groups. The retry has to wrap the write, not just the scan: ``scan_csv`` is
+    lazy, so the schema error only surfaces when ``sink_parquet`` pulls the rows.
+    """
+
+    def convert_one(group: ConversionGroup) -> int:
+        overrides: dict[str, type[pl.DataType]] = dict(metadata_types or {})
+        recovered: list[str] = []
+        while True:
+            try:
+                lazy_frames = [
+                    pl.scan_csv(
+                        f,
+                        separator=";",
+                        try_parse_dates=True,
+                        schema_overrides=overrides or None,
+                        infer_schema_length=10_000,
+                    )
+                    for f in group.sources
+                ]
+                combined = pl.concat(lazy_frames, how="diagonal_relaxed")
+                if collection_key == "forecast_local":
+                    combined = add_forecast_local_timestamp(combined)
+                _write_parquet_atomic(combined, group.out_path)
+                break
+            except (pl.exceptions.ComputeError, pl.exceptions.SchemaError) as e:
+                m = _COL_RE.search(str(e))
+                if not m:
+                    raise
+                col = m.group(1)
+                # If we already forced this column to Float64 and it still
+                # fails, we can't recover by widening dtype further.
+                if overrides.get(col) == pl.Float64:
+                    raise
+                overrides[col] = pl.Float64
+                recovered.append(col)
+        if recovered:
+            fixed = ", ".join(f"{c}→float" for c in recovered)
+            logger.info("  %s (%d files)... OK (%s)", group.out_path.name, len(group.sources), fixed)
+        else:
+            logger.info("  %s (%d files)... OK", group.out_path.name, len(group.sources))
+        return 0
+
+    return convert_one
+
+
 def convert_to_parquet(collection_key: str, bronze_dir: Path, parquet_dir: Path) -> int:
     """Convert all CSVs in a collection's bronze folder to combined Parquet files.
 
@@ -315,82 +443,17 @@ def convert_to_parquet(collection_key: str, bronze_dir: Path, parquet_dir: Path)
     """
     csv_dir = bronze_dir / collection_key
     out_dir = parquet_dir / collection_key
-    out_dir.mkdir(parents=True, exist_ok=True)
 
-    groups = group_csv_files(csv_dir, collection_key)
+    groups = [
+        ConversionGroup(out_dir / _group_out_name(collection_key, group_key), files)
+        for group_key, files in group_csv_files(csv_dir, collection_key).items()
+    ]
     if not groups:
         return 0
 
     # Load parameter type info from metadata once for the whole collection.
-    metadata_types = _load_metadata_types(csv_dir)
-
-    logger.info("Converting %s to Parquet:", collection_key)
-    converted = 0
-    skipped = 0
-    failed = 0
-    for group_key, files in sorted(groups.items()):
-        # Output name: smn_d_recent.parquet, smn_d.parquet, or smn.parquet
-        if group_key:
-            out_name = f"{collection_key}_{'_'.join(group_key)}.parquet"
-        else:
-            out_name = f"{collection_key}.parquet"
-        parquet_path = out_dir / out_name
-
-        # Skip if parquet is already newer than all CSVs in the group.
-        if parquet_path.exists():
-            parquet_mtime = parquet_path.stat().st_mtime
-            if all(f.stat().st_mtime <= parquet_mtime for f in files):
-                skipped += 1
-                continue
-
-        # Stay streaming the whole way: on dtype-drift errors (Int inferred from
-        # the first N rows but a later row carries a decimal), parse the column
-        # name out of the polars error, force it to Float64, and retry.  RSS
-        # stays bounded — the alternative of materialising every CSV blew up
-        # the driver on historical groups.
-        overrides: dict[str, type[pl.DataType]] = dict(metadata_types or {})
-        recovered: list[str] = []
-        try:
-            while True:
-                try:
-                    lazy_frames = [
-                        pl.scan_csv(
-                            f,
-                            separator=";",
-                            try_parse_dates=True,
-                            schema_overrides=overrides or None,
-                            infer_schema_length=10_000,
-                        )
-                        for f in files
-                    ]
-                    combined = pl.concat(lazy_frames, how="diagonal_relaxed")
-                    if collection_key == "forecast_local":
-                        combined = add_forecast_local_timestamp(combined)
-                    _write_parquet_atomic(combined, parquet_path)
-                    break
-                except (pl.exceptions.ComputeError, pl.exceptions.SchemaError) as e:
-                    m = _COL_RE.search(str(e))
-                    if not m:
-                        raise
-                    col = m.group(1)
-                    # If we already forced this column to Float64 and it still
-                    # fails, we can't recover by widening dtype further.
-                    if overrides.get(col) == pl.Float64:
-                        raise
-                    overrides[col] = pl.Float64
-                    recovered.append(col)
-            converted += 1
-            if recovered:
-                fixed = ", ".join(f"{c}→float" for c in recovered)
-                logger.info("  %s (%d files)... OK (%s)", out_name, len(files), fixed)
-            else:
-                logger.info("  %s (%d files)... OK", out_name, len(files))
-        except Exception as e:
-            failed += 1
-            logger.warning("  %s (%d files)... FAIL: %s", out_name, len(files), e)
-
-    logger.info("  Done: %d converted, %d skipped (up-to-date), %d failed", converted, skipped, failed)
-    return failed
+    metadata_types = load_metadata_types(csv_dir)
+    return run_conversions(groups, _convert_standard_group(collection_key, metadata_types), label=collection_key)
 
 
 _INDOOR_TIME_COLS = ["time.yy", "time.mm", "time.dd", "time.hh"]
@@ -434,51 +497,38 @@ def convert_climate_scenarios_indoor_to_parquet(bronze_dir: Path, parquet_dir: P
     {station}_{period}_{scenario}_{variant}, which become columns alongside a
     synthesised reference_timestamp. All files are concatenated into one Parquet.
     """
-    csv_dir = bronze_dir / "climate_scenarios_indoor"
-    out_dir = parquet_dir / "climate_scenarios_indoor"
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    csv_files = sorted(csv_dir.glob("*.csv"))
+    csv_files = sorted((bronze_dir / "climate_scenarios_indoor").glob("*.csv"))
     if not csv_files:
         return 0
 
-    out_path = out_dir / "climate_scenarios_indoor.parquet"
-    if out_path.exists():
-        out_mtime = out_path.stat().st_mtime
-        if all(f.stat().st_mtime <= out_mtime for f in csv_files):
-            logger.info("Converting climate_scenarios_indoor to Parquet: up-to-date — skipping")
+    def convert_one(group: ConversionGroup) -> int:
+        frames: list[pl.LazyFrame] = []
+        skipped = 0
+        for f in group.sources:
+            parsed = parse_indoor_filename(f.stem)
+            if parsed is None:
+                # The archive ships a metadata CSV alongside the data; not a failure.
+                skipped += 1
+                logger.info("  Skipping non-data file: %s", f.name)
+                continue
+            station, period, scenario, variant = parsed
+            frames.append(
+                add_indoor_columns(
+                    pl.scan_csv(f, separator=",", infer_schema_length=10_000, truncate_ragged_lines=True),
+                    station,
+                    period,
+                    scenario,
+                    variant,
+                )
+            )
+        if not frames:
             return 0
-
-    logger.info("Converting climate_scenarios_indoor to Parquet (%d files)...", len(csv_files))
-    frames: list[pl.LazyFrame] = []
-    skipped = 0
-    for f in csv_files:
-        parsed = parse_indoor_filename(f.stem)
-        if parsed is None:
-            skipped += 1
-            logger.info("  Skipping non-data file: %s", f.name)
-            continue
-        station, period, scenario, variant = parsed
-        lf = add_indoor_columns(
-            pl.scan_csv(f, separator=",", infer_schema_length=10_000, truncate_ragged_lines=True),
-            station,
-            period,
-            scenario,
-            variant,
-        )
-        frames.append(lf)
-
-    if not frames:
+        _write_parquet_atomic(pl.concat(frames, how="diagonal_relaxed"), group.out_path)
+        logger.info("  Done: wrote %s (%d files, %d non-data skipped)", group.out_path.name, len(frames), skipped)
         return 0
 
-    try:
-        _write_parquet_atomic(pl.concat(frames, how="diagonal_relaxed"), out_path)
-    except Exception as e:
-        logger.warning("  FAIL: %s", e)
-        return 1
-
-    logger.info("  Done: wrote %s (%d files, %d non-data skipped)", out_path.name, len(frames), skipped)
-    return 0
+    out_path = parquet_dir / "climate_scenarios_indoor" / "climate_scenarios_indoor.parquet"
+    return run_conversions([ConversionGroup(out_path, csv_files)], convert_one, label="climate_scenarios_indoor")
 
 
 _CS_HEADER_PREFIX = "DATE;"
@@ -578,42 +628,30 @@ def scan_climate_scenarios_csv(path: Path) -> pl.LazyFrame:
 
 def convert_climate_scenarios_to_parquet(bronze_dir: Path, parquet_dir: Path) -> int:
     """Convert CH2025 climate-scenario CSVs (with metadata preamble) to one Parquet."""
-    csv_dir = bronze_dir / "climate_scenarios"
-    out_dir = parquet_dir / "climate_scenarios"
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    csv_files = sorted(f for f in csv_dir.glob("*.csv") if "_meta_" not in f.name)
+    csv_files = sorted(f for f in (bronze_dir / "climate_scenarios").glob("*.csv") if "_meta_" not in f.name)
     if not csv_files:
         return 0
 
-    out_path = out_dir / "climate_scenarios.parquet"
-    if out_path.exists():
-        out_mtime = out_path.stat().st_mtime
-        if all(f.stat().st_mtime <= out_mtime for f in csv_files):
-            logger.info("Converting climate_scenarios to Parquet: up-to-date — skipping")
-            return 0
-
-    logger.info("Converting climate_scenarios to Parquet (%d files)...", len(csv_files))
-    frames: list[pl.LazyFrame] = []
-    failed = 0
-    for f in csv_files:
-        try:
-            frames.append(scan_climate_scenarios_csv(f))
-        except Exception as e:
-            failed += 1
-            logger.warning("  FAIL %s: %s", f.name, e)
-
-    if not frames:
+    def convert_one(group: ConversionGroup) -> int:
+        frames: list[pl.LazyFrame] = []
+        failed = 0
+        for f in group.sources:
+            try:
+                frames.append(scan_climate_scenarios_csv(f))
+            except Exception as e:
+                # One unreadable file must not cost the rest of the collection —
+                # skip it, write what parsed, and report it so the exit code
+                # still reflects it.
+                failed += 1
+                logger.warning("  FAIL %s: %s", f.name, e)
+        if not frames:
+            return failed
+        _write_parquet_atomic(pl.concat(frames, how="diagonal_relaxed"), group.out_path)
+        logger.info("  Done: wrote %s (%d files)", group.out_path.name, len(frames))
         return failed
 
-    try:
-        _write_parquet_atomic(pl.concat(frames, how="diagonal_relaxed"), out_path)
-    except Exception as e:
-        logger.warning("  FAIL: %s", e)
-        return failed + 1
-
-    logger.info("  Done: wrote %s (%d files)", out_path.name, len(frames))
-    return failed
+    out_path = parquet_dir / "climate_scenarios" / "climate_scenarios.parquet"
+    return run_conversions([ConversionGroup(out_path, csv_files)], convert_one, label="climate_scenarios")
 
 
 def convert_climate_normals_to_parquet(bronze_dir: Path, parquet_dir: Path) -> int:
@@ -622,42 +660,25 @@ def convert_climate_normals_to_parquet(bronze_dir: Path, parquet_dir: Path) -> i
     These files use tab separators, latin1 encoding, and have 8 header rows
     to skip before the actual data begins.
     """
-    txt_dir = bronze_dir / "climate_normals"
-    out_dir = parquet_dir / "climate_normals"
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    txt_files = sorted(txt_dir.glob("*.txt"))
+    txt_files = sorted((bronze_dir / "climate_normals").glob("*.txt"))
     if not txt_files:
         return 0
 
-    logger.info("Converting climate_normals to Parquet:")
-    converted = 0
-    skipped = 0
-    failed = 0
-    total = len(txt_files)
-    for i, txt_path in enumerate(txt_files, 1):
-        parquet_path = out_dir / txt_path.with_suffix(".parquet").name
+    def convert_one(group: ConversionGroup) -> int:
+        source = group.sources[0]
+        df = pl.read_csv(
+            source,
+            separator="\t",
+            skip_rows=8,
+            encoding="latin1",
+            infer_schema_length=None,
+            try_parse_dates=True,
+            truncate_ragged_lines=True,
+        )
+        _write_parquet_atomic(df, group.out_path, compression="snappy")
+        logger.info("  %s... Converted", source.name)
+        return 0
 
-        if parquet_path.exists() and parquet_path.stat().st_mtime >= txt_path.stat().st_mtime:
-            skipped += 1
-            continue
-
-        try:
-            df = pl.read_csv(
-                txt_path,
-                separator="\t",
-                skip_rows=8,
-                encoding="latin1",
-                infer_schema_length=None,
-                try_parse_dates=True,
-                truncate_ragged_lines=True,
-            )
-            _write_parquet_atomic(df, parquet_path, compression="snappy")
-            converted += 1
-            logger.info("  [%d/%d] %s... Converted", i, total, txt_path.name)
-        except Exception as e:
-            failed += 1
-            logger.warning("  [%d/%d] %s... FAIL: %s", i, total, txt_path.name, e)
-
-    logger.info("  Done: %d converted, %d skipped (up-to-date), %d failed", converted, skipped, failed)
-    return failed
+    out_dir = parquet_dir / "climate_normals"
+    groups = [ConversionGroup(out_dir / txt.with_suffix(".parquet").name, [txt]) for txt in txt_files]
+    return run_conversions(groups, convert_one, label="climate_normals")

--- a/src/foehn/grids.py
+++ b/src/foehn/grids.py
@@ -36,14 +36,15 @@ import contextlib
 import logging
 import re
 import warnings
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from foehn.assets import Asset, assets_of, collection_assets, other_extensions
 from foehn.collections import COLLECTION_META, COLLECTIONS, KIND_OF, DatasetKind, is_grid, kind
-from foehn.fetch import DEFAULT_WORKERS, Fetcher, FetchError, default_fetcher
+from foehn.fetch import Fetcher, FetchError, default_fetcher
+from foehn.transfer import fetch_all
 
 logger = logging.getLogger(__name__)
 
@@ -89,42 +90,58 @@ def _require_radar_deps():
         ) from exc
 
 
-# Per-kind read configuration. NetCDF keeps engine=None so xarray auto-detects NetCDF-3 vs -4/HDF5;
-# GRIB2 forces cfgrib and disables its .idx sidecar files (indexpath=""); HDF5
-# radar uses a bespoke ODIM-composite reader (``reader="odim"``) instead of an
-# xarray engine.
-#
-# ``max_files`` caps how many matched files a single open may combine. NetCDF
-# collections combine cleanly via combine_by_coords, so there's no cap. GRIB2 and
-# HDF5 are capped at 1 for open_dataset: ICON forecasts are on an unstructured
-# grid that combine_by_coords can't stack, and radar is one Cartesian composite
-# per timestep (thousands per collection). (to_zarr(stack=...) lifts the cap to
-# build cubes.) ``match_example`` seeds the "narrow your match" guidance. The cap
-# is checked against the *remote* listing before downloading, so an over-broad
-# match is rejected even when one matching file already happens to be cached.
-_GRID_READERS: dict[DatasetKind, dict] = {
-    DatasetKind.NETCDF_GRID: {
-        "suffixes": (".nc",),
-        "engine": None,
-        "backend_kwargs": None,
-        "max_files": None,
-        "match_example": None,
-    },
-    DatasetKind.GRIB2_GRID: {
-        "suffixes": (".grib2", ".grib"),
-        "engine": "cfgrib",
-        "backend_kwargs": {"indexpath": ""},
-        "max_files": 1,
-        "match_example": "202605231500-0-t_2m-ctrl",
-    },
-    DatasetKind.RADAR_GRID: {
-        "suffixes": (".h5",),
-        "reader": "odim",
-        "engine": None,
-        "backend_kwargs": None,
-        "max_files": 1,
-        "match_example": "cpc2613000000",
-    },
+@dataclass(frozen=True)
+class GridReader:
+    """How one gridded :class:`DatasetKind` is read.
+
+    Typed rather than a bare dict, for the same reason :class:`registry.KindSpec`
+    is: callers used to index this table with string literals, and the radar row
+    carried a ``reader`` key the others lacked — so every read of it needed a
+    ``.get`` and a typo was a runtime KeyError.
+    """
+
+    suffixes: tuple[str, ...]
+    """Asset extensions this kind reads. Other payloads (GeoTIFF/ZIP copies) are ignored."""
+
+    reader: Literal["xarray", "odim"] = "xarray"
+    """``"odim"`` selects the bespoke ODIM-composite reader instead of an xarray engine."""
+
+    engine: str | None = None
+    """xarray backend. None lets xarray auto-detect NetCDF-3 vs NetCDF-4/HDF5."""
+
+    backend_kwargs: dict | None = None
+    """Extra backend options — GRIB2 disables cfgrib's .idx sidecar files."""
+
+    max_files: int | None = None
+    """How many matched files one ``open_dataset`` may combine.
+
+    None for NetCDF, which combines cleanly via combine_by_coords. GRIB2 and HDF5
+    are capped at 1: ICON forecasts are on an unstructured grid combine_by_coords
+    can't stack, and radar is one Cartesian composite per timestep (thousands per
+    collection). ``to_zarr(stack=...)`` lifts the cap to build cubes. The cap is
+    checked against the *remote* listing before downloading, so an over-broad
+    match is rejected even when one matching file already happens to be cached.
+    """
+
+    match_example: str | None = None
+    """Seeds the "narrow your match" guidance for the capped kinds."""
+
+
+_GRID_READERS: dict[DatasetKind, GridReader] = {
+    DatasetKind.NETCDF_GRID: GridReader(suffixes=(".nc",)),
+    DatasetKind.GRIB2_GRID: GridReader(
+        suffixes=(".grib2", ".grib"),
+        engine="cfgrib",
+        backend_kwargs={"indexpath": ""},
+        max_files=1,
+        match_example="202605231500-0-t_2m-ctrl",
+    ),
+    DatasetKind.RADAR_GRID: GridReader(
+        suffixes=(".h5",),
+        reader="odim",
+        max_files=1,
+        match_example="cpc2613000000",
+    ),
 }
 
 
@@ -185,6 +202,11 @@ def _raise_if_too_many(collection_key: str, match: str | None, names: list[str],
         f"match={match!r} matched {len(names)} files for {collection_key!r}, {detail}. "
         f"Matches include:\n{examples}{more}"
     )
+
+
+def _exists(_asset: Asset, filepath: Path) -> bool:
+    """A :data:`~foehn.transfer.SkipRule`: a grid file already on disk is never refetched."""
+    return filepath.exists()
 
 
 def _grid_assets(items: list[dict], suffixes: tuple[str, ...], match: str | None) -> tuple[list[Asset], set[str]]:
@@ -266,30 +288,18 @@ def _ensure_grid_files(
     # (e.g. a whole forecast run) can't pull hundreds of files off the network.
     _raise_if_too_many(collection_key, match, [a.name for a in matched], max_files)
 
-    out_dir.mkdir(parents=True, exist_ok=True)
-    paths: list[Path] = []
-    # Deduplicate by destination: a STAC item can list one asset under several
-    # keys, and two workers streaming into the same ``.part`` would corrupt it.
-    targets: dict[Path, str] = {}
-    for asset in matched:
-        filepath = out_dir / asset.name
-        paths.append(filepath)
-        if not filepath.exists() and filepath not in targets:
-            targets[filepath] = asset.href
-
-    if targets:
-        # Fetch concurrently, like the CSV path. Serial downloads made the network
-        # the dominant cost of building a cube: stack="auto" admits up to
-        # _HYPERCUBE_MAX_FILES files, each previously fetched one after another.
-        def _fetch(filepath: Path, href: str) -> None:
-            fetcher.stream(href, filepath)
-
-        with ThreadPoolExecutor(max_workers=min(DEFAULT_WORKERS, len(targets))) as pool:
-            futures = [pool.submit(_fetch, fp, href) for fp, href in targets.items()]
-            for fut in as_completed(futures):
-                fut.result()  # surface the first failure; a grid read can't proceed without its files
-
-    return sorted(set(paths))
+    # ``on_error="raise"`` rather than the download paths' count-and-continue: a
+    # grid read cannot proceed on a partial set, so the first failure is fatal.
+    # Destination de-duplication and the worker pool are the transfer module's.
+    fetch_all(
+        matched,
+        out_dir,
+        fetcher=fetcher,
+        skip=_exists,
+        on_error="raise",
+        label="grid file",
+    )
+    return sorted({out_dir / asset.name for asset in matched})
 
 
 # CF-compliant temporal base units that xarray/cftime can decode. Anything else
@@ -598,25 +608,25 @@ def open_dataset(
 
     # Single-file formats (GRIB2, radar) have thousands of files per collection,
     # so an unfiltered open would download the lot — require a narrowing match.
-    if reader["max_files"] == 1 and match is None:
+    if reader.max_files == 1 and match is None:
         raise ValueError(
             f"Dataset {dataset!r} is a {fmt} collection of many single-field files; opening it "
             "unfiltered would download them all. Narrow to one file with match=, e.g. "
-            f'foehn.open_dataset({dataset!r}, match="{reader["match_example"]}").'
+            f'foehn.open_dataset({dataset!r}, match="{reader.match_example}").'
         )
 
     data_dir = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     bronze_dir = data_dir / "bronze"
     files = _ensure_grid_files(
-        dataset, bronze_dir, suffixes=reader["suffixes"], match=match, max_files=reader["max_files"], fetcher=fetcher
+        dataset, bronze_dir, suffixes=reader.suffixes, match=match, max_files=reader.max_files, fetcher=fetcher
     )
 
-    if reader.get("reader") == "odim":
+    if reader.reader == "odim":
         ds = _open_odim_composite(xr, files[0])
     else:
-        engine = engine if engine is not None else reader["engine"]
+        engine = engine if engine is not None else reader.engine
         try:
-            ds = _open_grid(xr, files, engine, reader["backend_kwargs"])
+            ds = _open_grid(xr, files, engine, reader.backend_kwargs)
         except Exception as exc:
             if len(files) > 1:
                 raise ValueError(
@@ -691,14 +701,16 @@ def _write_zarr(ds, store: Path, mode: str, append_dim: str | None = None) -> No
             ds.to_zarr(store, mode=mode)
 
 
-def _to_zarr_stacked(dataset, dataset_kind, fmt, *, variables, match, data_dir, store, mode, fetcher) -> Path:
+def _to_zarr_stacked(dataset, *, variables, match, data_dir, store, mode, fetcher) -> Path:
     """Stack a matched set of radar composites into one ``(time, y, x)`` Zarr cube.
 
     Written incrementally — one timestep appended at a time along ``time`` — so
     peak memory stays at a single file no matter how many timesteps the match
     spans, and no dask is needed.
     """
+    dataset_kind = kind(dataset)
     if dataset_kind is not DatasetKind.RADAR_GRID:
+        fmt = COLLECTION_META[dataset]["format"]
         raise ValueError(
             f"stack='time' is only supported for radar (HDF5) collections; {dataset!r} is {fmt}. "
             "NetCDF multi-file matches already combine via match=; GRIB2 uses stack='auto'."
@@ -715,7 +727,7 @@ def _to_zarr_stacked(dataset, dataset_kind, fmt, *, variables, match, data_dir, 
 
     root = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     # No single-file cap here: stacking deliberately wants the whole matched set.
-    files = _ensure_grid_files(dataset, root / "bronze", suffixes=reader["suffixes"], match=match, fetcher=fetcher)
+    files = _ensure_grid_files(dataset, root / "bronze", suffixes=reader.suffixes, match=match, fetcher=fetcher)
     store_path = _resolve_store(dataset, match, data_dir, store)
     store_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -742,7 +754,7 @@ def _to_zarr_stacked(dataset, dataset_kind, fmt, *, variables, match, data_dir, 
 _HYPERCUBE_MAX_FILES = 1000
 
 
-def _to_zarr_hypercube(dataset, dataset_kind, fmt, *, variables, match, data_dir, store, mode, fetcher) -> Path:
+def _to_zarr_hypercube(dataset, *, variables, match, data_dir, store, mode, fetcher) -> Path:
     """Combine matched GRIB2 files into one N-D cube over their varying axes.
 
     Each ICON/KENDA file is a single (variable, member, lead time, reference time)
@@ -752,7 +764,9 @@ def _to_zarr_hypercube(dataset, dataset_kind, fmt, *, variables, match, data_dir
     derived ``valid_time`` is dropped before combining (it conflicts on concat)
     and recomputed afterwards. The whole set is loaded into memory at once.
     """
+    dataset_kind = kind(dataset)
     if dataset_kind is not DatasetKind.GRIB2_GRID:
+        fmt = COLLECTION_META[dataset]["format"]
         raise ValueError(
             f"stack='auto' is only supported for GRIB2 collections; {dataset!r} is {fmt}. "
             "Radar uses stack='time'; NetCDF multi-file matches already combine via match=."
@@ -770,12 +784,12 @@ def _to_zarr_hypercube(dataset, dataset_kind, fmt, *, variables, match, data_dir
     root = Path(data_dir) if data_dir else Path.cwd() / "data" / "meteoswiss"
     bronze_dir = root / "bronze"
     files = _ensure_grid_files(
-        dataset, bronze_dir, suffixes=reader["suffixes"], match=match, max_files=_HYPERCUBE_MAX_FILES, fetcher=fetcher
+        dataset, bronze_dir, suffixes=reader.suffixes, match=match, max_files=_HYPERCUBE_MAX_FILES, fetcher=fetcher
     )
     store_path = _resolve_store(dataset, match, data_dir, store)
     store_path.parent.mkdir(parents=True, exist_ok=True)
 
-    datasets = [xr.open_dataset(f, engine="cfgrib", backend_kwargs=reader["backend_kwargs"]) for f in sorted(files)]
+    datasets = [xr.open_dataset(f, engine="cfgrib", backend_kwargs=reader.backend_kwargs) for f in sorted(files)]
     # Promote whichever independent axes actually differ across the matched files.
     varying = [
         coord
@@ -868,7 +882,6 @@ def to_zarr(
     """
     _validate_grid_dataset(dataset)
     dataset_kind = kind(dataset)
-    fmt = COLLECTION_META[dataset]["format"]
 
     if stack is not None:
         if stack not in ("auto", "time"):
@@ -885,9 +898,9 @@ def to_zarr(
         }
         # "auto" routes to each format's best cube builder; "time" is the explicit radar path.
         if stack == "time" or dataset_kind is DatasetKind.RADAR_GRID:
-            return _to_zarr_stacked(dataset, dataset_kind, fmt, **kwargs)  # radar: incremental (time, y, x)
+            return _to_zarr_stacked(dataset, **kwargs)  # radar: incremental (time, y, x)
         if dataset_kind is DatasetKind.GRIB2_GRID:
-            return _to_zarr_hypercube(dataset, dataset_kind, fmt, **kwargs)  # forecasts: N-D combine_by_coords
+            return _to_zarr_hypercube(dataset, **kwargs)  # forecasts: N-D combine_by_coords
         # NetCDF + stack="auto": open_dataset already combines a multi-file match,
         # so just fall through to the normal single-write path below.
 

--- a/src/foehn/mcp_server.py
+++ b/src/foehn/mcp_server.py
@@ -24,8 +24,12 @@ logger = logging.getLogger(__name__)
 
 # Datasets that can be loaded as tabular data (CSV-backed).
 _LOADABLE_DATASETS = sorted(registry.tabular_datasets())
-_VALID_FREQUENCIES = {"t", "h", "d", "m", "y"}
-_VALID_TIME_SLICES = {"historical", "recent", "now"}
+
+# Categories are this layer's own: ``list_datasets`` filters the catalogue here
+# rather than in foehn, so nothing below validates the value. The dataset,
+# frequency, time-slice and sort vocabularies are *not* here — they belong to
+# ``foehn.load``'s contract, and a second copy of them at this seam could only
+# ever agree with it or drift from it.
 _VALID_CATEGORIES = {"A", "C", "D", "E"}
 
 # The tabular query tools are read-only against the MeteoSwiss API (describe_grid
@@ -236,18 +240,10 @@ def load_data(
         limit: Maximum rows to return (default 50, max 500). Use filters to stay
             within limits on large datasets.
     """
-    if dataset not in COLLECTIONS:
-        raise ValueError(f"Unknown dataset {dataset!r}. Call list_datasets() to see options.")
-    if not registry.spec(dataset).tabular:
-        fmt = COLLECTION_META[dataset]["format"]
-        raise ValueError(f"Dataset {dataset!r} is {fmt} (binary/grid) and cannot be loaded as tabular data.")
-    if frequency and frequency.lower() not in _VALID_FREQUENCIES:
-        raise ValueError(f"Invalid frequency {frequency!r}. Valid options: t, h, d, m, y.")
-    if time_slice and time_slice.lower() not in _VALID_TIME_SLICES:
-        raise ValueError(f"Invalid time_slice {time_slice!r}. Valid options: historical, recent, now.")
-    if sort and sort not in ("asc", "desc"):
-        raise ValueError(f"Invalid sort {sort!r}. Valid options: asc, desc.")
-
+    # Unknown dataset, grid datasets, and the frequency/time_slice/sort
+    # vocabularies are all foehn.load's contract — it raises on each of them, so
+    # restating them here could only drift. The row cap is genuinely this
+    # layer's: it bounds what goes back to a model's context window.
     limit = min(max(1, limit), 500)
 
     df = foehn.load(
@@ -306,16 +302,6 @@ def describe_data(
         date_to: End date (inclusive), ISO format "YYYY-MM-DD".
         drop_null: Only count rows where this column is not null.
     """
-    if dataset not in COLLECTIONS:
-        raise ValueError(f"Unknown dataset {dataset!r}. Call list_datasets() to see options.")
-    if not registry.spec(dataset).tabular:
-        fmt = COLLECTION_META[dataset]["format"]
-        raise ValueError(f"Dataset {dataset!r} is {fmt} (binary/grid) and cannot be described.")
-    if frequency and frequency.lower() not in _VALID_FREQUENCIES:
-        raise ValueError(f"Invalid frequency {frequency!r}. Valid options: t, h, d, m, y.")
-    if time_slice and time_slice.lower() not in _VALID_TIME_SLICES:
-        raise ValueError(f"Invalid time_slice {time_slice!r}. Valid options: historical, recent, now.")
-
     df = foehn.load(
         dataset,
         station=station,
@@ -395,9 +381,10 @@ def describe_grid(
             collections (e.g. match="rhiresd" for daily precipitation).
         variables: Restrict the summary to these data variable(s).
     """
-    if dataset not in COLLECTIONS:
-        raise ValueError(f"Unknown dataset {dataset!r}. Call list_datasets() to see options.")
-    if dataset not in _INSPECTABLE_GRIDS:
+    # open_dataset rejects an unknown dataset itself. This one is restated on
+    # purpose: its message names the MCP tools rather than the Python functions,
+    # which is the guidance an LLM caller can act on.
+    if dataset in COLLECTIONS and dataset not in _INSPECTABLE_GRIDS:
         raise ValueError(f"Dataset {dataset!r} is CSV/tabular. Use describe_data() or load_data() instead.")
     # open_dataset enforces the single-file match= requirement for GRIB2/radar.
 
@@ -442,9 +429,6 @@ def get_parameters(dataset: str) -> list[Parameter]:
     Args:
         dataset: Dataset name (e.g. "smn"). Call list_datasets() to see options.
     """
-    if dataset not in COLLECTIONS:
-        raise ValueError(f"Unknown dataset {dataset!r}. Call list_datasets() to see options.")
-
     return [Parameter(**row) for row in foehn.parameters(dataset).to_dicts()]
 
 
@@ -459,9 +443,6 @@ def get_stations(dataset: str) -> list[Station]:
     Args:
         dataset: Dataset name (e.g. "smn"). Call list_datasets() to see options.
     """
-    if dataset not in COLLECTIONS:
-        raise ValueError(f"Unknown dataset {dataset!r}. Call list_datasets() to see options.")
-
     return [Station(**row) for row in foehn.stations(dataset).to_dicts()]
 
 
@@ -475,9 +456,6 @@ def get_inventory(dataset: str) -> list[InventoryEntry]:
     Args:
         dataset: Dataset name (e.g. "smn"). Call list_datasets() to see options.
     """
-    if dataset not in COLLECTIONS:
-        raise ValueError(f"Unknown dataset {dataset!r}. Call list_datasets() to see options.")
-
     return [InventoryEntry(**row) for row in foehn.inventory(dataset).to_dicts()]
 
 

--- a/src/foehn/readers.py
+++ b/src/foehn/readers.py
@@ -1,0 +1,349 @@
+"""The three tabular read paths, and the query they all take.
+
+``download`` and ``convert`` route through :mod:`foehn.registry`; loading used to
+route through an if-ladder in ``api`` instead, because hoisting the readers into
+the registry would have inverted ``registry → api``. The fix was not to hoist but
+to drop: these readers depend on ``assets``, ``client``, ``convert`` and
+``fetch``, never on ``api``, so they sit *below* the registry and
+:class:`~foehn.registry.KindSpec` can carry a ``load`` adapter beside its
+``download`` and ``convert`` ones. All three pipeline stages now route the
+same way.
+
+Each reader returns the concatenated frame for its kind. The filters that apply
+uniformly — ``drop_null``, ``columns``, ``sort``, ``limit`` and the calendar
+predicates — are applied once by ``api.load`` afterwards, so a reader never has
+to know a dataset's key columns or what ``sort`` orders by.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import polars as pl
+
+from foehn._urls import asset_filename
+from foehn.assets import assets_of, collection_assets, hrefs, select
+from foehn.client import check_zip_size
+from foehn.collections import COLLECTIONS, DatasetKind, kind
+from foehn.convert import (
+    add_forecast_local_timestamp,
+    add_indoor_columns,
+    decode_meteoswiss_csv,
+    parse_climate_scenarios_csv,
+    parse_csv_bytes,
+    parse_indoor_filename,
+    parse_metadata_types,
+    utf8_meteoswiss_csv,
+)
+from foehn.fetch import DEFAULT_WORKERS, Fetcher
+
+# A ``date_to`` of exactly "YYYY-MM-DD" names a whole day, not its midnight.
+_BARE_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass(frozen=True)
+class Filters:
+    """One load query, normalised.
+
+    The eleven filter arguments used to be spelled out at every level: the public
+    ``load``, each of the three readers, both shared filter passes, the CLI's
+    kwargs ladder and both MCP tools. Packing them once — behind the public
+    signature, which is unchanged — means the readers take one parameter, and the
+    station/granularity normalisation that was written out three times happens
+    here instead.
+    """
+
+    stations: frozenset[str] | None = None
+    """Lowercased station abbreviations, or None for no filter."""
+
+    granularities: frozenset[str] | None = None
+    """Lowercased granularity codes, or None for no filter."""
+
+    time_slices: tuple[str, ...] = ("recent",)
+    year: tuple[int, ...] | None = None
+    month: tuple[int, ...] | None = None
+    date_from: str | None = None
+    date_to: str | None = None
+    columns: tuple[str, ...] | None = None
+    drop_null: str | None = None
+    sort: str | None = None
+    limit: int | None = None
+    workers: int = DEFAULT_WORKERS
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        station: str | list[str] | None = None,
+        frequency: str | list[str] | None = None,
+        time_slice: str | list[str] | None = None,
+        year: int | list[int] | None = None,
+        month: int | list[int] | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        columns: list[str] | None = None,
+        drop_null: str | None = None,
+        sort: str | None = None,
+        limit: int | None = None,
+        workers: int = DEFAULT_WORKERS,
+    ) -> Filters:
+        """Normalise the public keyword arguments into one value.
+
+        An empty list means "no filter", not "match nothing" — the latter is
+        never what a caller wants, and the MCP layer used to strip empty lists on
+        ``load()``'s behalf. The archive and preamble readers used to read an
+        empty list the other way and error out; they now agree with the main path.
+        """
+        return cls(
+            stations=_lower_set(station),
+            granularities=_lower_set(frequency),
+            time_slices=_as_tuple(time_slice) or ("recent",),
+            year=_as_tuple(year),
+            month=_as_tuple(month),
+            date_from=date_from,
+            date_to=date_to,
+            columns=tuple(columns) if columns else None,
+            drop_null=drop_null,
+            sort=sort,
+            limit=limit,
+            workers=workers,
+        )
+
+    @property
+    def has_calendar_filter(self) -> bool:
+        """Whether any of the calendar predicates was asked for."""
+        return any(x is not None for x in (self.year, self.month, self.date_from, self.date_to))
+
+
+def _lower_set(value: str | list[str] | None) -> frozenset[str] | None:
+    if not value:
+        return None
+    return frozenset({value.lower()} if isinstance(value, str) else {v.lower() for v in value})
+
+
+def _as_tuple(value):
+    if value is None:
+        return None
+    if isinstance(value, (str, int)):
+        return (value,)
+    return tuple(value) or None
+
+
+class Reader(Protocol):
+    """How one :class:`~foehn.collections.DatasetKind` becomes a DataFrame."""
+
+    def __call__(self, dataset: str, filters: Filters, *, fetcher: Fetcher) -> pl.DataFrame: ...
+
+
+# --- Shared row predicates ---
+
+
+def apply_time_filters(df: pl.DataFrame, filters: Filters) -> pl.DataFrame:
+    """Apply the timestamp row predicates, on one parsed CSV or on the concatenation.
+
+    ``read_standard`` runs these on each CSV as it is parsed, instead of only on
+    the concatenated result. These are all per-row predicates, so filtering early
+    is equivalent — but it bounds peak memory by the largest single station file
+    rather than by the whole matched set. ``drop_null`` deliberately stays in the
+    post-filter: a frame missing that column keeps every row here, while after a
+    diagonal concat the column exists as null across those rows and they are
+    dropped.
+    """
+    ts = "reference_timestamp"
+    if filters.year is not None:
+        df = df.filter(pl.col(ts).dt.year().is_in(list(filters.year)))
+    if filters.month is not None:
+        df = df.filter(pl.col(ts).dt.month().is_in(list(filters.month)))
+    # Cast the timestamp column to Datetime before comparing: some daily/monthly
+    # files parse ``reference_timestamp`` as a Date, and comparing Date vs the
+    # Datetime literal would raise. Date→Datetime and Datetime→Datetime are both safe.
+    if filters.date_from is not None:
+        df = df.filter(pl.col(ts).cast(pl.Datetime) >= pl.lit(filters.date_from).str.to_datetime())
+    if filters.date_to is not None:
+        bound = pl.lit(filters.date_to).str.to_datetime()
+        if _BARE_DATE_RE.match(filters.date_to):
+            # A bare "YYYY-MM-DD" means the whole of that day. Comparing <= the
+            # parsed midnight is right for d/m/y (timestamps sit at 00:00) but
+            # silently drops every 10-minute and hourly reading after 00:00, so
+            # bound the day exclusively at the next midnight instead.
+            df = df.filter(pl.col(ts).cast(pl.Datetime) < bound.dt.offset_by("1d"))
+        else:
+            df = df.filter(pl.col(ts).cast(pl.Datetime) <= bound)
+    return df
+
+
+def _fetch_frames(fetch_one, targets: list[str], workers: int) -> list[pl.DataFrame]:
+    """Parse each target concurrently.
+
+    The fetcher is safe to share across the pool: it hands each worker thread its
+    own session.
+    """
+    if len(targets) == 1 or workers <= 1:
+        return [fetch_one(t) for t in targets]
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        return list(pool.map(fetch_one, targets))
+
+
+# --- The readers ---
+
+
+def read_standard(dataset: str, filters: Filters, *, fetcher: Fetcher) -> pl.DataFrame:
+    """Per-station CSVs split by time slice and granularity — the main path.
+
+    Also serves the forecast kind, whose filenames carry no time slice: there the
+    newest run is what bounds the set instead.
+    """
+    collection_id = COLLECTIONS[dataset]
+
+    # 1. Fetch metadata types for schema inference.
+    metadata_types: dict[str, type[pl.DataType]] = {}
+    coll = fetcher.collection(collection_id)
+    for asset in collection_assets(coll, suffixes=(".csv",), contains="_meta_parameters"):
+        metadata_types = parse_metadata_types(decode_meteoswiss_csv(fetcher.get(asset.href, timeout=60).body))
+        break
+
+    # 2. Get STAC items and collect matching CSV URLs.
+    items = fetcher.items(collection_id)
+
+    # Filter items by station (item id = station abbreviation).
+    if filters.stations is not None:
+        items = [item for item in items if item.get("id", "").lower() in filters.stations]
+
+    # A forecast item is one *day*, not one forecast, and the newest one is empty
+    # until that day's runs publish — so keep all items and narrow to the newest
+    # run by filename below. Ranking on ``datetime`` would not help either: it is a
+    # refresh timestamp, identical across items to the microsecond.
+    is_forecast = kind(dataset) is DatasetKind.FORECAST_CSV
+    if is_forecast and items:
+        items.sort(key=lambda x: x.get("id", ""))
+
+    csv_hrefs = hrefs(
+        select(
+            assets_of(items, suffixes=(".csv",)),
+            time_slices=None if is_forecast else list(filters.time_slices),
+            granularities=filters.granularities,
+            latest_run=is_forecast,
+        )
+    )
+
+    if not csv_hrefs:
+        described = (
+            f"station={sorted(filters.stations) if filters.stations else None}, "
+            f"frequency={sorted(filters.granularities) if filters.granularities else None}, "
+            f"time_slice={list(filters.time_slices)}"
+        )
+        raise ValueError(f"No CSV files found for {dataset!r} with {described}.")
+
+    # 3. Download and parse each CSV concurrently.
+    # With an explicit ``columns=``, tell the parser up front instead of parsing all
+    # ~42 columns of every station file and selecting afterwards. The frame retained
+    # per station drops by an order of magnitude, which is what bounds peak memory
+    # while the whole matched set is assembled. Everything the later filters and the
+    # concat rely on has to survive the projection.
+    wanted_columns: set[str] | None = None
+    if filters.columns:
+        wanted_columns = {"station_abbr", "reference_timestamp", *filters.columns}
+        if filters.drop_null:
+            wanted_columns.add(filters.drop_null)
+        if dataset == "forecast_local":
+            wanted_columns.add("Date")  # reference_timestamp is derived from it
+
+    def _fetch(href: str) -> pl.DataFrame:
+        # Zero-copy when the payload is already UTF-8 (the usual case): these are
+        # the big files, and ``workers`` of them are in flight at once.
+        body = fetcher.get(href, timeout=60).body
+        frame = parse_csv_bytes(utf8_meteoswiss_csv(body), metadata_types, wanted_columns=wanted_columns)
+        # Drop the rows this call can never return *before* they reach the
+        # concat. Every frame is otherwise held in full until the whole matched
+        # set is materialised, so a narrow year= over many stations peaked at the
+        # size of the entire time slice. forecast_local has no reference_timestamp
+        # of its own — derive it here so its frames can be narrowed too.
+        if dataset == "forecast_local":
+            frame = add_forecast_local_timestamp(frame)
+        if "reference_timestamp" in frame.columns:
+            frame = apply_time_filters(frame, filters)
+        return frame
+
+    df = pl.concat(_fetch_frames(_fetch, csv_hrefs, filters.workers), how="diagonal_relaxed")
+
+    # forecast_local has no reference_timestamp; derive it from the compact Date column.
+    if dataset == "forecast_local":
+        df = add_forecast_local_timestamp(df)
+    return df
+
+
+def read_preamble(dataset: str, filters: Filters, *, fetcher: Fetcher) -> pl.DataFrame:
+    """CH2025 climate-scenario CSVs (metadata preamble + wide model table).
+
+    Dates are nominal (0001..0030 on a 365-day calendar), so the calendar-based
+    year/month/date filters do not apply here — they are rejected before this is
+    reached; ``sort`` orders lexically by the string ``date`` column.
+    """
+    items = fetcher.items(COLLECTIONS[dataset])
+    if filters.stations is not None:
+        items = [item for item in items if item.get("id", "").lower() in filters.stations]
+
+    csv_hrefs = hrefs(assets_of(items, suffixes=(".csv",), excludes="_meta_"))
+    if not csv_hrefs:
+        stations = sorted(filters.stations) if filters.stations else None
+        raise ValueError(f"No climate-scenario CSVs found for {dataset!r} with station={stations}.")
+
+    def _fetch(href: str) -> pl.DataFrame:
+        return parse_climate_scenarios_csv(fetcher.get(href, timeout=120).body, asset_filename(href))
+
+    return pl.concat(_fetch_frames(_fetch, csv_hrefs, filters.workers), how="diagonal_relaxed")
+
+
+def read_archive(dataset: str, filters: Filters, *, fetcher: Fetcher) -> pl.DataFrame:
+    """A single ZIP of per-station CSVs (indoor scenarios).
+
+    Unlike the per-station collections, this is a single archive, so the whole
+    ZIP is fetched and parsed in memory; the station filter picks which member
+    CSVs are parsed.
+    """
+    items = fetcher.items(COLLECTIONS[dataset])
+    archives = assets_of(items, suffixes=(".zip",))
+    if not archives:
+        raise ValueError(f"No .zip asset found for {dataset!r}.")
+    zip_href = archives[0].href
+
+    archive = fetcher.get(zip_href, timeout=300).body
+
+    frames: list[pl.DataFrame] = []
+    with zipfile.ZipFile(io.BytesIO(archive)) as zf:
+        # Everything below is parsed in memory — refuse a decompression bomb.
+        check_zip_size(zf, asset_filename(zip_href))
+        for name in zf.namelist():
+            if not name.endswith(".csv"):
+                continue
+            parsed = parse_indoor_filename(Path(name).stem)
+            if parsed is None:
+                continue
+            st, period, scenario, variant = parsed
+            if filters.stations is not None and st.lower() not in filters.stations:
+                continue
+            with zf.open(name) as fh:
+                frame = pl.read_csv(fh.read(), separator=",", infer_schema_length=10_000, truncate_ragged_lines=True)
+            frames.append(add_indoor_columns(frame, st, period, scenario, variant))
+
+    if not frames:
+        stations = sorted(filters.stations) if filters.stations else None
+        raise ValueError(f"No indoor data found for {dataset!r} with station={stations}.")
+
+    return pl.concat(frames, how="diagonal_relaxed")
+
+
+__all__ = [
+    "Filters",
+    "Reader",
+    "apply_time_filters",
+    "read_archive",
+    "read_preamble",
+    "read_standard",
+]

--- a/src/foehn/registry.py
+++ b/src/foehn/registry.py
@@ -4,11 +4,11 @@ One table replacing the routing ladders that used to sit in ``api``, ``cli`` and
 the Databricks ingest script, each re-deriving from a different set of dataset
 keys. Callers ask the registry instead of testing membership.
 
-Layering: ``collections`` (dataset facts) → ``client``/``convert`` (adapters) →
-this module → ``api``/``cli``/``mcp_server``. The load readers deliberately stay
-in ``api``: they are its implementation, and hoisting them here just to fill a
-column would invert that dependency. What the registry says about loading is
-which filters a kind supports, which is a fact about the data.
+Layering: ``collections`` (dataset facts) → ``client``/``convert``/``readers``
+(adapters) → this module → ``api``/``cli``/``mcp_server``. All three pipeline
+stages route through the table: the load readers live in ``foehn.readers``,
+below this module, so ``load`` can sit in :class:`KindSpec` beside ``download``
+and ``convert`` rather than as an if-ladder in ``api``.
 """
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
 
 from foehn.client import (
     DownloadResult,
@@ -33,10 +34,41 @@ from foehn.convert import (
 )
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
 
-# Every download adapter takes the same arguments and ignores what its kind does
-# not use, so callers never have to know which ones apply. The alternative — a
-# per-kind call shape — is the ladder we are removing.
-DownloadAdapter = Callable[..., DownloadResult]
+if TYPE_CHECKING:
+    import polars as pl
+
+from foehn.readers import (
+    Filters,
+    Reader,
+    read_archive,
+    read_preamble,
+    read_standard,
+)
+
+
+class DownloadAdapter(Protocol):
+    """Every download adapter takes the same arguments and ignores what its kind
+    does not use, so callers never have to know which ones apply. The alternative
+    — a per-kind call shape — is the ladder we are removing.
+
+    Spelled as a Protocol rather than ``Callable[..., DownloadResult]``: with
+    ``...`` neither the adapters nor the call site were checked at all, so the
+    "everyone takes everything" convention was documented but not enforced.
+    """
+
+    def __call__(
+        self,
+        dataset: str,
+        bronze_dir: Path,
+        *,
+        time_slice: list[str],
+        since: str | None,
+        workers: int,
+        force: bool,
+        fetcher: Fetcher,
+    ) -> DownloadResult: ...
+
+
 ConvertAdapter = Callable[[str, Path, Path], int]
 
 
@@ -59,13 +91,7 @@ def _download_standard(
     coll = download_collection(
         dataset, bronze_dir, data_types=time_slice, since=since, workers=workers, fetcher=fetcher
     )
-    return DownloadResult(
-        total_assets=meta.total_assets + coll.total_assets,
-        downloaded=meta.downloaded + coll.downloaded,
-        skipped=meta.skipped + coll.skipped,
-        failed=meta.failed + coll.failed,
-        filenames=meta.filenames + coll.filenames,
-    )
+    return meta + coll
 
 
 def _download_archive(dataset: str, bronze_dir: Path, *, force: bool, fetcher: Fetcher, **_: object) -> DownloadResult:
@@ -106,6 +132,9 @@ class KindSpec:
 
     download: DownloadAdapter
     convert: ConvertAdapter | None
+    load: Reader | None
+    """How this kind becomes a DataFrame. None for the grid kinds (use open_dataset)."""
+
     tabular: bool
     """Loadable as a Polars DataFrame. False for the grid kinds (use open_dataset)."""
 
@@ -126,6 +155,7 @@ KINDS: dict[DatasetKind, KindSpec] = {
     DatasetKind.STANDARD_CSV: KindSpec(
         download=_download_standard,
         convert=_convert_standard,
+        load=read_standard,
         tabular=True,
         supports_granularity=True,
         supports_calendar_filters=True,
@@ -133,6 +163,7 @@ KINDS: dict[DatasetKind, KindSpec] = {
     DatasetKind.PREAMBLE_CSV: KindSpec(
         download=_download_standard,
         convert=_convert_preamble,
+        load=read_preamble,
         tabular=True,
         supports_granularity=False,
         # Dates are nominal (0001..0030 on a 365-day calendar), so the calendar
@@ -145,6 +176,7 @@ KINDS: dict[DatasetKind, KindSpec] = {
     DatasetKind.ARCHIVE_CSV: KindSpec(
         download=_download_archive,
         convert=_convert_archive,
+        load=read_archive,
         tabular=True,
         supports_granularity=False,
         supports_calendar_filters=True,
@@ -153,6 +185,7 @@ KINDS: dict[DatasetKind, KindSpec] = {
     DatasetKind.FORECAST_CSV: KindSpec(
         download=_download_standard,
         convert=_convert_standard,
+        load=read_standard,
         tabular=True,
         supports_granularity=False,
         supports_calendar_filters=True,
@@ -160,6 +193,7 @@ KINDS: dict[DatasetKind, KindSpec] = {
     DatasetKind.NETCDF_GRID: KindSpec(
         download=_download_netcdf,
         convert=None,
+        load=None,
         tabular=False,
         supports_granularity=False,
         supports_calendar_filters=False,
@@ -167,6 +201,7 @@ KINDS: dict[DatasetKind, KindSpec] = {
     DatasetKind.GRIB2_GRID: KindSpec(
         download=_download_grib2,
         convert=None,
+        load=None,
         tabular=False,
         supports_granularity=False,
         supports_calendar_filters=False,
@@ -174,6 +209,7 @@ KINDS: dict[DatasetKind, KindSpec] = {
     DatasetKind.RADAR_GRID: KindSpec(
         download=_download_grib2,
         convert=None,
+        load=None,
         tabular=False,
         supports_granularity=False,
         supports_calendar_filters=False,
@@ -206,6 +242,19 @@ def download(
         force=force,
         fetcher=fetcher,
     )
+
+
+def load(dataset: str, filters: Filters, *, fetcher: Fetcher) -> pl.DataFrame:
+    """Load *dataset* by whichever reader its kind uses.
+
+    Callers guard on ``spec(dataset).tabular`` first — the grid kinds have no
+    reader, which is a fact about the kind rather than a branch each caller
+    re-derives.
+    """
+    reader = spec(dataset).load
+    if reader is None:
+        raise ValueError(f"Dataset {dataset!r} is a binary/grid dataset and cannot be loaded as a DataFrame.")
+    return reader(dataset, filters, fetcher=fetcher)
 
 
 def convert(dataset: str, bronze_dir: Path, parquet_dir: Path) -> int:

--- a/src/foehn/transfer.py
+++ b/src/foehn/transfer.py
@@ -1,0 +1,280 @@
+"""Turning a set of :class:`~foehn.assets.Asset` into files on disk.
+
+:mod:`foehn.fetch` owns *one* HTTP call. This module owns *many*: the worker
+pool, destination de-duplication, per-asset failure isolation, ETag bookkeeping,
+atomic writes and the counting that produces a :class:`DownloadResult`.
+
+Before this module that loop was written five times — once in each of
+``client.download_collection``, ``download_metadata``, ``download_grib2`` and
+``download_netcdf``, and once more in ``grids._ensure_grid_files``. All five
+were the same body; only three things ever varied, and they are the three
+parameters :func:`fetch_all` takes:
+
+* which assets to skip without asking the network (``skip``),
+* how one asset becomes one file (``write``),
+* whether a failed asset is counted or fatal (``on_error``).
+
+The duplication also showed in the interface: ``DownloadResult.total_assets``
+used to mean something different depending on which of the five produced it, so
+a caller had to know its provenance to read the field. With one producer it has
+one meaning, and ``downloaded + skipped + failed == total_assets`` holds.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from foehn.assets import Asset
+from foehn.convert import utf8_meteoswiss_csv
+from foehn.fetch import DEFAULT_WORKERS, Fetcher
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DownloadResult:
+    """Summary of a download call.
+
+    Callers use this to decide whether to run expensive downstream work
+    (e.g. Spark MERGE INTO) without scanning the output directory.
+
+    ``downloaded + skipped + failed == total_assets`` always holds:
+    ``total_assets`` is every asset handed to :func:`fetch_all`, ``skipped``
+    counts both the ones ``skip`` rejected locally and the ones the server
+    answered 304 for, and destination collisions count as skipped too.
+    """
+
+    total_assets: int = 0
+    downloaded: int = 0
+    skipped: int = 0
+    failed: int = 0
+    filenames: list[str] = field(default_factory=list)
+
+    def __add__(self, other: DownloadResult) -> DownloadResult:
+        """Combine two results, for callers that run more than one pass.
+
+        The standard CSV path downloads collection metadata and item data as two
+        passes and reports them as one; both of its callers used to sum the
+        fields by hand, and only one of them summed all of them.
+        """
+        return DownloadResult(
+            total_assets=self.total_assets + other.total_assets,
+            downloaded=self.downloaded + other.downloaded,
+            skipped=self.skipped + other.skipped,
+            failed=self.failed + other.failed,
+            filenames=self.filenames + other.filenames,
+        )
+
+
+# --- Atomic writes ---
+
+
+def atomic_write_bytes(path: Path, data: bytes | memoryview) -> None:
+    """Write bytes via a sibling temp file + Path.replace so readers never see a torn write."""
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        tmp.write_bytes(data)
+        tmp.replace(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Write text via a sibling temp file + Path.replace so readers never see a torn write."""
+    atomic_write_bytes(path, text.encode("utf-8"))
+
+
+# --- Writers: how one asset becomes one file ---
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """What a :data:`Writer` did with one asset.
+
+    ``downloaded=False`` is the conditional-GET case: the server said 304, so
+    the file on disk is already current. ``etag`` is the validator to store for
+    next time, or None when the response carried none.
+    """
+
+    downloaded: bool
+    etag: str | None = None
+
+
+Writer = Callable[[Fetcher, Asset, Path, str | None], WriteResult]
+"""``(fetcher, asset, destination, stored etag) -> WriteResult``. Runs on a worker thread."""
+
+SkipRule = Callable[[Asset, Path], bool]
+"""``(asset, destination) -> skip it?``. Runs on the main thread, before anything is queued."""
+
+
+def stream_to_disk(fetcher: Fetcher, asset: Asset, path: Path, etag: str | None) -> WriteResult:
+    """Stream a binary asset straight to disk. Used for GRIB2, HDF5, NetCDF and ZIP."""
+    fetcher.stream(asset.href, path)
+    return WriteResult(downloaded=True)
+
+
+def csv_to_disk(fetcher: Fetcher, asset: Asset, path: Path, etag: str | None) -> WriteResult:
+    """Fetch a CSV conditionally, re-encode to UTF-8, and write it.
+
+    Only sends the stored ETag when the local file is still there — otherwise a
+    304 would report "skipped" over a file that no longer exists.
+
+    MeteoSwiss CSVs are usually UTF-8 but some are Windows-1252; normalise to
+    UTF-8. Bytes in, bytes out — decoding to str here only to re-encode on write
+    would hold three copies of a multi-hundred-MB CSV at once, times ``workers``.
+    """
+    validator = etag if etag and path.exists() else None
+    fetched = fetcher.get(asset.href, etag=validator, timeout=60)
+    if fetched.not_modified:
+        return WriteResult(downloaded=False)
+    atomic_write_bytes(path, utf8_meteoswiss_csv(fetched.body))
+    return WriteResult(downloaded=True, etag=fetched.etag)
+
+
+# --- The engine ---
+
+OnError = Literal["count", "raise"]
+
+
+def _dedupe_by_destination(pairs: list[tuple[Asset, Path]]) -> tuple[list[tuple[Asset, Path]], int]:
+    """Keep one (asset, destination) pair per destination path, and count the drops.
+
+    Two hrefs resolving to the same local filename would have workers streaming
+    into the same ``.part`` file at once and corrupting it. A collision is an
+    upstream naming quirk we can't resolve here, so keep the first and say so
+    rather than dropping one silently.
+    """
+    kept: dict[Path, Asset] = {}
+    dropped = 0
+    for asset, filepath in pairs:
+        if filepath in kept:
+            logger.warning("  Duplicate destination %s — skipping %s", filepath.name, asset.href)
+            dropped += 1
+            continue
+        kept[filepath] = asset
+    return [(asset, filepath) for filepath, asset in kept.items()], dropped
+
+
+def fetch_all(
+    assets: Iterable[Asset],
+    out_dir: Path,
+    *,
+    fetcher: Fetcher,
+    workers: int = DEFAULT_WORKERS,
+    write: Writer = stream_to_disk,
+    skip: SkipRule | None = None,
+    etags: dict[str, str] | None = None,
+    on_error: OnError = "count",
+    label: str = "file",
+) -> DownloadResult:
+    """Fetch *assets* into *out_dir*, concurrently, and report what happened.
+
+    Args:
+        assets: What to fetch. Each lands at ``out_dir / asset.name``.
+        out_dir: Destination directory, created if absent.
+        fetcher: The network port. Safe to share across the pool — it hands each
+            worker thread its own session.
+        workers: Concurrent transfers.
+        write: How one asset becomes one file. :func:`stream_to_disk` for
+            binaries, :func:`csv_to_disk` for the conditional-GET CSV path.
+        skip: Decided locally, before anything is queued — an existence check, or
+            a "local mtime is newer than the STAC ``updated``" check. Assets it
+            rejects are counted as skipped and never touched.
+        etags: The ETag store, read when submitting and updated as results
+            arrive. Mutated in place; the caller owns loading and saving it.
+        on_error: ``"count"`` isolates a failed asset so one transient 404 or
+            timeout can't abort the batch (and discard the ETags collected from
+            the others). ``"raise"`` re-raises the first failure, for callers
+            that cannot proceed with a partial set — a grid read needs its files.
+        label: Noun for the log lines ("CSV", "metadata", "binary", "grid").
+
+    Returns:
+        A :class:`DownloadResult` whose four counts sum to ``total_assets``.
+    """
+    assets = list(assets)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    queued: list[tuple[Asset, Path]] = []
+    preskipped = 0
+    for asset in assets:
+        filepath = out_dir / asset.name
+        if skip is not None and skip(asset, filepath):
+            preskipped += 1
+            continue
+        queued.append((asset, filepath))
+
+    queued, collisions = _dedupe_by_destination(queued)
+    skipped = preskipped + collisions
+
+    total = len(queued)
+    downloaded = 0
+    failed = 0
+    filenames: list[str] = []
+
+    if total:
+        logger.info("  %d %s(s) to process", total, label)
+        with ThreadPoolExecutor(max_workers=min(workers, total)) as pool:
+            # ETags are read here, on the main thread, and written below as
+            # results arrive — also on the main thread. The store is never
+            # touched from a worker.
+            future_to_asset = {
+                pool.submit(write, fetcher, asset, filepath, (etags or {}).get(asset.href)): asset
+                for asset, filepath in queued
+            }
+            for i, fut in enumerate(as_completed(future_to_asset), 1):
+                asset = future_to_asset[fut]
+                try:
+                    outcome = fut.result()
+                except Exception as exc:
+                    if on_error == "raise":
+                        raise
+                    failed += 1
+                    logger.warning("  [%d/%d] FAILED: %s — %s", i, total, asset.href, exc)
+                    continue
+                if not outcome.downloaded:
+                    skipped += 1
+                    continue
+                if etags is not None:
+                    if outcome.etag:
+                        etags[asset.href] = outcome.etag
+                    else:
+                        # Server returned 200 without an ETag. Keeping the old one
+                        # would re-send it as If-None-Match forever, so this asset
+                        # would re-download every run and never once be skipped.
+                        etags.pop(asset.href, None)
+                downloaded += 1
+                filenames.append(asset.name)
+                logger.info("  [%d/%d] Downloaded: %s", i, total, asset.name)
+
+    if skipped:
+        logger.info("  Skipped %d unchanged %s(s)", skipped, label)
+    if failed:
+        logger.warning("  %d %s(s) failed to download", failed, label)
+    logger.info("  Done — %d %s(s) downloaded", downloaded, label)
+
+    return DownloadResult(
+        total_assets=len(assets),
+        downloaded=downloaded,
+        skipped=skipped,
+        failed=failed,
+        filenames=filenames,
+    )
+
+
+__all__ = [
+    "DownloadResult",
+    "SkipRule",
+    "WriteResult",
+    "Writer",
+    "atomic_write_bytes",
+    "atomic_write_text",
+    "csv_to_disk",
+    "fetch_all",
+    "stream_to_disk",
+]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -769,7 +769,7 @@ def test_date_to_bare_date_includes_the_whole_final_day():
     00:00) but silently drops every 10-minute and hourly reading after 00:00,
     while the docstring promises an inclusive bound.
     """
-    from foehn.api import _apply_post_filters
+    from foehn.readers import Filters, apply_time_filters
 
     df = pl.DataFrame(
         {
@@ -783,16 +783,16 @@ def test_date_to_bare_date_includes_the_whole_final_day():
         }
     ).with_columns(pl.col("reference_timestamp").str.to_datetime())
 
-    out = _apply_post_filters(df, "smn", date_from="2025-08-30", date_to="2025-08-31")
+    out = apply_time_filters(df, Filters.build(date_from="2025-08-30", date_to="2025-08-31"))
     assert len(out) == 4
 
     # The day after is still excluded — the bound is the next midnight, exclusive.
-    assert len(_apply_post_filters(df, "smn", date_to="2025-08-30")) == 1
+    assert len(apply_time_filters(df, Filters.build(date_to="2025-08-30"))) == 1
 
 
 def test_date_to_with_explicit_time_stays_an_exact_bound():
     """An explicit timestamp means exactly that instant, not the end of its day."""
-    from foehn.api import _apply_post_filters
+    from foehn.readers import Filters, apply_time_filters
 
     df = pl.DataFrame(
         {
@@ -801,7 +801,7 @@ def test_date_to_with_explicit_time_stays_an_exact_bound():
         }
     ).with_columns(pl.col("reference_timestamp").str.to_datetime())
 
-    out = _apply_post_filters(df, "smn", date_to="2025-08-31 12:00:00")
+    out = apply_time_filters(df, Filters.build(date_to="2025-08-31 12:00:00"))
     assert len(out) == 2
 
 
@@ -809,7 +809,7 @@ def test_date_filter_on_date_typed_column_does_not_raise():
     """date_from/date_to must work when reference_timestamp parsed as Date, not Datetime."""
     from datetime import date
 
-    from foehn.api import _apply_post_filters
+    from foehn.readers import Filters, apply_time_filters
 
     df = pl.DataFrame(
         {
@@ -819,7 +819,7 @@ def test_date_filter_on_date_typed_column_does_not_raise():
     )
     assert df["reference_timestamp"].dtype == pl.Date  # guard: column really is Date-typed
 
-    out = _apply_post_filters(df, "smn", date_from="2025-03-01", date_to="2025-08-31")
+    out = apply_time_filters(df, Filters.build(date_from="2025-03-01", date_to="2025-08-31"))
     assert len(out) == 1
     assert out["reference_timestamp"][0] == date(2025, 6, 1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -323,7 +323,10 @@ def test_load_prints_dataframe(capsys):
     fake_df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     with patch("foehn.api.load", return_value=fake_df) as mock_load, patch("sys.argv", ["foehn", "load", "smn"]):
         main()
-    mock_load.assert_called_once_with("smn")
+    mock_load.assert_called_once()
+    assert mock_load.call_args.args == ("smn",)
+    # Nothing was asked for, so every filter goes across as "no filter".
+    assert all(v is None for k, v in mock_load.call_args.kwargs.items() if k != "workers")
     out = capsys.readouterr().out
     assert "3 rows x 2 columns" in out
 
@@ -333,7 +336,11 @@ def test_load_with_filters():
     argv = ["foehn", "load", "smn", "--station", "BER", "--frequency", "d", "--time-slice", "recent", "-n", "5"]
     with patch("foehn.api.load", return_value=fake_df) as mock_load, patch("sys.argv", argv):
         main()
-    mock_load.assert_called_once_with("smn", station=["BER"], frequency=["d"], time_slice=["recent"])
+    mock_load.assert_called_once()
+    assert mock_load.call_args.args == ("smn",)
+    assert mock_load.call_args.kwargs | {"station": ["BER"], "frequency": ["d"], "time_slice": ["recent"]} == (
+        mock_load.call_args.kwargs
+    )
 
 
 def test_load_with_post_filters():
@@ -365,17 +372,23 @@ def test_load_with_post_filters():
     ]
     with patch("foehn.api.load", return_value=fake_df) as mock_load, patch("sys.argv", argv):
         main()
-    mock_load.assert_called_once_with(
-        "smn",
-        station=["BER"],
-        frequency=["d"],
-        year=[2025],
-        month=[6, 7],
-        date_from="2025-06-01",
-        date_to="2025-08-31",
-        columns=["temp", "precip"],
-        drop_null="temp",
-        sort="desc",
+    mock_load.assert_called_once()
+    assert mock_load.call_args.args == ("smn",)
+    forwarded = mock_load.call_args.kwargs
+    assert (
+        forwarded
+        | {
+            "station": ["BER"],
+            "frequency": ["d"],
+            "year": [2025],
+            "month": [6, 7],
+            "date_from": "2025-06-01",
+            "date_to": "2025-08-31",
+            "columns": ["temp", "precip"],
+            "drop_null": "temp",
+            "sort": "desc",
+        }
+        == forwarded
     )
 
 
@@ -385,7 +398,9 @@ def test_load_forwards_limit_and_workers():
     argv = ["foehn", "load", "smn", "--limit", "5", "--workers", "3"]
     with patch("foehn.api.load", return_value=fake_df) as mock_load, patch("sys.argv", argv):
         main()
-    mock_load.assert_called_once_with("smn", limit=5, workers=3)
+    mock_load.assert_called_once()
+    assert mock_load.call_args.kwargs["limit"] == 5
+    assert mock_load.call_args.kwargs["workers"] == 3
 
 
 # --- metadata subcommand ---

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,7 +4,9 @@ from foehn.api import list_datasets
 from foehn.collections import (
     COLLECTION_META,
     COLLECTIONS,
+    GRANULARITIES,
     KIND_OF,
+    TIME_SLICES,
     DatasetKind,
     forecast_run_from_filename,
     time_slice_from_filename,
@@ -171,3 +173,23 @@ def test_forecast_run_from_filename_rejects_non_forecast_names():
 def test_forecast_runs_sort_lexicographically():
     runs = ["202607210600", "202606300000", "202607192300"]
     assert max(runs) == "202607210600"
+
+
+# --- Filter vocabularies ---
+# These used to be asserted against a second copy in mcp_server. They are facts
+# about MeteoSwiss's filenames, so they are tested where they are defined.
+
+
+def test_time_slice_vocabulary():
+    assert {"historical", "recent", "now"} == set(TIME_SLICES)
+
+
+def test_granularity_vocabulary():
+    assert {"t", "h", "d", "m", "y"} == set(GRANULARITIES)
+
+
+def test_every_advertised_frequency_is_in_the_vocabulary():
+    """list_datasets() doubles as the per-dataset valid-values list for frequency=."""
+    for key, meta in COLLECTION_META.items():
+        assert set(meta["frequencies"]) <= set(GRANULARITIES), key
+        assert set(meta["time_slices"]) <= set(TIME_SLICES), key

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -7,8 +7,6 @@ import polars as pl
 import pytest
 
 from foehn.convert import (
-    _load_metadata_types,
-    _parse_metadata_types,
     add_forecast_local_timestamp,
     convert_climate_normals_to_parquet,
     convert_climate_scenarios_indoor_to_parquet,
@@ -16,8 +14,10 @@ from foehn.convert import (
     convert_to_parquet,
     decode_meteoswiss_csv,
     group_csv_files,
+    load_metadata_types,
     parse_climate_scenarios_csv,
     parse_csv_bytes,
+    parse_metadata_types,
     scan_climate_scenarios_csv,
 )
 
@@ -200,12 +200,12 @@ def test_convert_to_parquet_no_csv_is_noop(tmp_path):
     assert not (parquet_dir / "smn").exists() or not list((parquet_dir / "smn").iterdir())
 
 
-# --- _load_metadata_types ---
+# --- load_metadata_types ---
 
 
 def test_load_metadata_types(smn_bronze_dir):
     """Metadata file should produce a mapping of parameter names to Polars dtypes."""
-    types = _load_metadata_types(smn_bronze_dir / "smn")
+    types = load_metadata_types(smn_bronze_dir / "smn")
     assert types["tre200d0"] == pl.Float64
     assert types["rre150d0"] == pl.Float64
     assert types["ure200d0"] == pl.Int64
@@ -215,7 +215,7 @@ def test_load_metadata_types(smn_bronze_dir):
 
 def test_load_metadata_types_no_file(tmp_path):
     """Returns empty dict when no metadata file exists."""
-    assert _load_metadata_types(tmp_path) == {}
+    assert load_metadata_types(tmp_path) == {}
 
 
 def test_convert_applies_metadata_types(smn_bronze_dir, tmp_path):
@@ -259,17 +259,17 @@ def test_convert_climate_normals_readable(climate_normals_bronze_dir, tmp_path):
     assert len(df) == 2
 
 
-# --- _parse_metadata_types edge cases ---
+# --- parse_metadata_types edge cases ---
 
 
 def test_parse_metadata_types_invalid_content():
     """Unparseable content returns empty dict."""
-    assert _parse_metadata_types(b"not;valid;csv\x00\xff") == {}
+    assert parse_metadata_types(b"not;valid;csv\x00\xff") == {}
 
 
 def test_parse_metadata_types_missing_columns():
     """CSV without expected columns returns empty dict."""
-    assert _parse_metadata_types(b"col_a;col_b\nfoo;bar\n") == {}
+    assert parse_metadata_types(b"col_a;col_b\nfoo;bar\n") == {}
 
 
 # --- parse_csv_bytes edge cases ---

--- a/tests/test_ingest_delta.py
+++ b/tests/test_ingest_delta.py
@@ -106,11 +106,11 @@ def test_build_schema_overrides_no_metadata():
 
 
 def test_scan_and_collect(smn_bronze_dir):
-    from foehn.convert import _load_metadata_types
+    from foehn.convert import load_metadata_types
 
     csv_dir = smn_bronze_dir / "smn"
     files = sorted(csv_dir.glob("ogd-smn_*_d_recent.csv"))
-    metadata_types = _load_metadata_types(csv_dir)
+    metadata_types = load_metadata_types(csv_dir)
 
     df = _scan_and_collect(files, metadata_types)
 
@@ -122,22 +122,22 @@ def test_scan_and_collect(smn_bronze_dir):
 
 
 def test_scan_and_collect_parses_timestamps(smn_bronze_dir):
-    from foehn.convert import _load_metadata_types
+    from foehn.convert import load_metadata_types
 
     csv_dir = smn_bronze_dir / "smn"
     files = sorted(csv_dir.glob("ogd-smn_*_d_recent.csv"))
-    metadata_types = _load_metadata_types(csv_dir)
+    metadata_types = load_metadata_types(csv_dir)
 
     df = _scan_and_collect(files, metadata_types)
     assert df["reference_timestamp"].dtype == pl.Datetime
 
 
 def test_scan_and_collect_single_file(smn_bronze_dir):
-    from foehn.convert import _load_metadata_types
+    from foehn.convert import load_metadata_types
 
     csv_dir = smn_bronze_dir / "smn"
     files = [sorted(csv_dir.glob("ogd-smn_*_d_recent.csv"))[0]]
-    metadata_types = _load_metadata_types(csv_dir)
+    metadata_types = load_metadata_types(csv_dir)
 
     df = _scan_and_collect(files, metadata_types)
     assert len(df) == 3

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,8 +16,6 @@ from foehn.mcp_server import (
     _INSPECTABLE_GRIDS,
     _LOADABLE_DATASETS,
     _VALID_CATEGORIES,
-    _VALID_FREQUENCIES,
-    _VALID_TIME_SLICES,
     Dataset,
     DataSummary,
     GridSummary,
@@ -57,12 +55,6 @@ class TestConstants:
 
     def test_inspectable_grids_are_all_gridded(self):
         assert sorted(registry.grid_datasets()) == _INSPECTABLE_GRIDS
-
-    def test_valid_frequencies(self):
-        assert {"t", "h", "d", "m", "y"} == _VALID_FREQUENCIES
-
-    def test_valid_time_slices(self):
-        assert {"historical", "recent", "now"} == _VALID_TIME_SLICES
 
     def test_valid_categories(self):
         assert {"A", "C", "D", "E"} == _VALID_CATEGORIES

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,0 +1,81 @@
+"""Tests at :mod:`foehn.readers`' interface.
+
+The three read paths themselves are covered through ``foehn.load`` in
+``test_api``, which is where callers meet them. These cover the query object the
+readers take — the normalisation that used to be written out once per reader.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from foehn.fetch import DEFAULT_WORKERS
+from foehn.readers import Filters, apply_time_filters
+
+# --- Normalisation ---
+
+
+def test_station_and_frequency_are_lowercased_sets():
+    filters = Filters.build(station=["BER", "Zur"], frequency="D")
+    assert filters.stations == frozenset({"ber", "zur"})
+    assert filters.granularities == frozenset({"d"})
+
+
+def test_a_single_string_becomes_a_one_element_set():
+    assert Filters.build(station="BER").stations == frozenset({"ber"})
+
+
+def test_empty_list_means_no_filter_not_match_nothing():
+    """All three readers now agree; the archive and preamble ones used to error."""
+    filters = Filters.build(station=[], frequency=[])
+    assert filters.stations is None
+    assert filters.granularities is None
+
+
+def test_time_slice_defaults_to_recent():
+    assert Filters.build().time_slices == ("recent",)
+    assert Filters.build(time_slice="now").time_slices == ("now",)
+    assert Filters.build(time_slice=["historical", "recent"]).time_slices == ("historical", "recent")
+
+
+def test_scalar_year_and_month_become_tuples():
+    filters = Filters.build(year=2025, month=[6, 7])
+    assert filters.year == (2025,)
+    assert filters.month == (6, 7)
+
+
+def test_workers_defaults_to_the_shared_concurrency():
+    assert Filters.build().workers == DEFAULT_WORKERS
+
+
+def test_has_calendar_filter_reports_any_of_the_four():
+    assert not Filters.build().has_calendar_filter
+    assert Filters.build(year=2025).has_calendar_filter
+    assert Filters.build(month=7).has_calendar_filter
+    assert Filters.build(date_from="2025-01-01").has_calendar_filter
+    assert Filters.build(date_to="2025-01-01").has_calendar_filter
+
+
+def test_filters_are_hashable_and_frozen():
+    """A query is a value: readers can hold one without copying it defensively."""
+    assert hash(Filters.build(station="BER", year=[2025, 2026])) is not None
+
+
+# --- The shared time predicates ---
+
+
+def _frame(timestamps: list[str]) -> pl.DataFrame:
+    return pl.DataFrame({"reference_timestamp": timestamps}).with_columns(
+        pl.col("reference_timestamp").str.to_datetime()
+    )
+
+
+def test_no_filters_is_identity():
+    df = _frame(["2025-06-01 00:00", "2025-07-01 00:00"])
+    assert len(apply_time_filters(df, Filters.build())) == 2
+
+
+def test_year_and_month_combine():
+    df = _frame(["2025-06-01 00:00", "2025-07-01 00:00", "2026-07-01 00:00"])
+    out = apply_time_filters(df, Filters.build(year=2025, month=7))
+    assert len(out) == 1

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,161 @@
+"""Tests at :mod:`foehn.transfer`'s interface.
+
+The five download paths that used to carry their own copy of this loop are still
+covered through their own interfaces (``test_client``, ``test_grids``). These
+test the engine itself: the counting invariant, the two failure policies, ETag
+bookkeeping, and destination collisions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from foehn.assets import Asset
+from foehn.fetch import FetchError
+from foehn.transfer import DownloadResult, csv_to_disk, fetch_all, stream_to_disk
+from tests.fakes import InMemoryFetcher
+
+
+def asset(name: str, href: str | None = None, *, updated: str = "") -> Asset:
+    return Asset.from_stac(name, {"href": href or f"https://data.geo.admin.ch/x/{name}", "updated": updated})
+
+
+# --- The counting invariant ---
+
+
+def test_counts_sum_to_total(tmp_path):
+    fetcher = InMemoryFetcher()
+    fetcher.default_body = b"payload"
+    assets = [asset("a.nc"), asset("b.nc"), asset("c.nc")]
+    (tmp_path / "c.nc").parent.mkdir(parents=True, exist_ok=True)
+
+    result = fetch_all(assets, tmp_path, fetcher=fetcher)
+
+    assert result.total_assets == 3
+    assert result.downloaded + result.skipped + result.failed == result.total_assets
+    assert sorted(result.filenames) == ["a.nc", "b.nc", "c.nc"]
+
+
+def test_skip_rule_counts_as_skipped_not_missing(tmp_path):
+    fetcher = InMemoryFetcher()
+    fetcher.default_body = b"payload"
+    (tmp_path / "cached.nc").write_bytes(b"already here")
+
+    result = fetch_all(
+        [asset("cached.nc"), asset("fresh.nc")],
+        tmp_path,
+        fetcher=fetcher,
+        skip=lambda _a, path: path.exists(),
+    )
+
+    assert (result.total_assets, result.downloaded, result.skipped, result.failed) == (2, 1, 1, 0)
+    assert result.filenames == ["fresh.nc"]
+    # The skipped file was never fetched.
+    assert fetcher.streams == ["https://data.geo.admin.ch/x/fresh.nc"]
+
+
+def test_destination_collision_is_kept_once_and_counted(tmp_path):
+    """Two hrefs resolving to one filename must not have two workers on one .part."""
+    fetcher = InMemoryFetcher()
+    fetcher.default_body = b"payload"
+    duplicates = [
+        asset("same.nc", "https://data.geo.admin.ch/one/same.nc"),
+        asset("same.nc", "https://data.geo.admin.ch/two/same.nc"),
+    ]
+
+    result = fetch_all(duplicates, tmp_path, fetcher=fetcher)
+
+    assert (result.total_assets, result.downloaded, result.skipped) == (2, 1, 1)
+    assert len(fetcher.streams) == 1
+
+
+# --- Failure policy ---
+
+
+def test_on_error_count_isolates_one_failure(tmp_path):
+    fetcher = InMemoryFetcher()
+    fetcher.default_body = b"payload"
+    fetcher.fail("https://data.geo.admin.ch/x/bad.nc")
+
+    result = fetch_all([asset("good.nc"), asset("bad.nc")], tmp_path, fetcher=fetcher)
+
+    assert (result.downloaded, result.failed) == (1, 1)
+    assert result.filenames == ["good.nc"]
+    assert (tmp_path / "good.nc").exists()
+
+
+def test_on_error_raise_surfaces_the_first_failure(tmp_path):
+    """A grid read cannot proceed on a partial set, so its first failure is fatal."""
+    fetcher = InMemoryFetcher()
+    fetcher.default_body = b"payload"
+    fetcher.fail("https://data.geo.admin.ch/x/bad.nc")
+
+    with pytest.raises(FetchError):
+        fetch_all([asset("bad.nc")], tmp_path, fetcher=fetcher, on_error="raise")
+
+
+# --- ETag bookkeeping ---
+
+
+def test_etag_304_counts_as_skipped_and_keeps_the_file(tmp_path):
+    fetcher = InMemoryFetcher()
+    fetcher.add_body("https://data.geo.admin.ch/x/s.csv", b"col\n1\n", etag="v1")
+    (tmp_path / "s.csv").write_bytes(b"col\n1\n")
+    etags = {"https://data.geo.admin.ch/x/s.csv": "v1"}
+
+    result = fetch_all([asset("s.csv")], tmp_path, fetcher=fetcher, write=csv_to_disk, etags=etags)
+
+    assert (result.downloaded, result.skipped) == (0, 1)
+    assert etags == {"https://data.geo.admin.ch/x/s.csv": "v1"}
+
+
+def test_stored_etag_is_ignored_when_the_local_file_is_gone(tmp_path):
+    """A 304 must never report "skipped" over a file that no longer exists."""
+    fetcher = InMemoryFetcher()
+    fetcher.add_body("https://data.geo.admin.ch/x/s.csv", b"col\n1\n", etag="v1")
+    etags = {"https://data.geo.admin.ch/x/s.csv": "v1"}
+
+    result = fetch_all([asset("s.csv")], tmp_path, fetcher=fetcher, write=csv_to_disk, etags=etags)
+
+    assert result.downloaded == 1
+    assert (tmp_path / "s.csv").read_bytes() == b"col\n1\n"
+
+
+def test_a_200_without_an_etag_drops_the_stored_one(tmp_path):
+    """Keeping it would re-send If-None-Match forever, so the asset would never skip."""
+    fetcher = InMemoryFetcher()
+    fetcher.add_body("https://data.geo.admin.ch/x/s.csv", b"col\n1\n")  # no ETag
+    (tmp_path / "s.csv").write_bytes(b"stale")
+    etags = {"https://data.geo.admin.ch/x/s.csv": "v-old"}
+
+    fetch_all([asset("s.csv")], tmp_path, fetcher=fetcher, write=csv_to_disk, etags=etags)
+
+    assert etags == {}
+
+
+def test_csv_writer_normalises_windows_1252_to_utf8(tmp_path):
+    fetcher = InMemoryFetcher()
+    fetcher.add_body("https://data.geo.admin.ch/x/s.csv", "name\nZ\xfcrich\n".encode("windows-1252"))
+
+    fetch_all([asset("s.csv")], tmp_path, fetcher=fetcher, write=csv_to_disk)
+
+    assert (tmp_path / "s.csv").read_bytes().decode("utf-8") == "name\nZürich\n"
+
+
+# --- Result composition ---
+
+
+def test_results_add(tmp_path):
+    """The standard CSV path reports its metadata and data passes as one result."""
+    meta = DownloadResult(total_assets=1, downloaded=1, filenames=["m.csv"])
+    data = DownloadResult(total_assets=2, downloaded=1, skipped=1, failed=1, filenames=["a.csv"])
+
+    combined = meta + data
+
+    assert (combined.total_assets, combined.downloaded, combined.skipped, combined.failed) == (3, 2, 1, 1)
+    assert combined.filenames == ["m.csv", "a.csv"]
+
+
+def test_empty_input_is_a_noop(tmp_path):
+    result = fetch_all([], tmp_path, fetcher=InMemoryFetcher(), write=stream_to_disk)
+    assert result == DownloadResult()


### PR DESCRIPTION
The concurrent-download loop was written five times (four in client, one in grids) and the conversion bookkeeping four times. Both now have one owner: transfer.fetch_all and convert.run_conversions. Callers pass what actually varies — a skip rule, a writer, a failure policy — instead of a copy of the loop. DownloadResult's counts now mean the same thing whoever produced them.

The load readers move to foehn.readers, below the registry rather than inside api, so KindSpec carries a load adapter beside download and convert and the if-ladder in api.load goes. The eleven filter arguments are packed into one Filters value behind the unchanged public signature.

The MCP layer stops restating foehn's vocabulary: GRANULARITIES and TIME_SLICES live in collections and load() enforces them, which also means an unknown frequency or sort now raises instead of quietly matching nothing.

Also: _GRID_READERS becomes a typed dataclass, DownloadAdapter becomes a Protocol with a real signature, and the three helpers imported across module seams are named public because that is what they already were.