### PR TITLE
Split upstream's CSV conventions out of the convert stage

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -140,6 +140,15 @@ What a download reports: `total_assets`, `downloaded`, `skipped`, `failed` and
 the new filenames. The first is every **Asset** the call was given, and the
 other three sum to it.
 
+**MeteoSwiss CSV**:
+How MeteoSwiss writes a CSV and what foehn needs to read one back: the
+UTF-8/Windows-1252 fallback, the semicolon separator, the dtypes named in a
+**Collection**'s `_meta_parameters.csv`, the `KEY;VALUE` preamble, and the
+filename rules that carry station, **Granularity**, **Time slice** and
+**Forecast run**. Upstream's conventions, below every pipeline that reads them —
+the load path, the convert stage and the Databricks ingest script alike.
+_Avoid_: parsing, format (a **Format** is a value; this is the rules for one)
+
 **Reader**:
 How one **Dataset kind** becomes a Polars DataFrame — one per tabular kind,
 selected from the registry exactly as its download and convert paths are. Owns
@@ -173,6 +182,8 @@ _Avoid_: query, params, options
 - Every network read of a **Collection**, **Item** or **Asset** goes through the **Fetcher**.
 - Every **Asset** written to **Bronze** goes through **Transfer**, which calls the **Fetcher**.
 - Every path foehn reads or writes comes from a **Workspace**.
+- Every module that reads a MeteoSwiss file goes through **MeteoSwiss CSV**; only
+  the convert stage depends on the Parquet one.
 - A **Dataset kind** has one download path and one convert path, and at most one
   of a **Reader** (tabular) or a **Grid reader** (gridded) — never both, and
   neither for **Direct ZIP**.
@@ -196,6 +207,11 @@ _Avoid_: query, params, options
   it and `foehn.download("climate_normals")` raised "Unknown dataset". Resolved:
   it is a **Direct ZIP** **Dataset** like any other. What "download everything"
   means is now *not gridded* rather than *tabular*, which is what it always meant.
+- Upstream's CSV conventions and the Bronze → Parquet stage lived in one module,
+  so `transfer` — the download engine — depended on the Parquet converter for one
+  byte-level helper, and the gridded read path did too, through it. Five modules
+  imported that one and four of them wanted only the conventions. Resolved:
+  **MeteoSwiss CSV** is its own module and `convert` has a single consumer.
 - The MCP guide restated `load()`'s filter vocabulary as prose and had drifted:
   it told callers `sort` defaults to `"asc"` when an omitted `sort` does not sort
   at all. Resolved: the granularity and time-slice tokens carry their own labels

--- a/scripts/ingest_delta.py
+++ b/scripts/ingest_delta.py
@@ -32,7 +32,7 @@ from pyspark.sql import SparkSession
 
 from foehn import registry
 from foehn.collections import DatasetKind, kind
-from foehn.convert import group_csv_files, load_metadata_types, parse_csv_bytes
+from foehn.meteocsv import group_csv_files, load_metadata_types, parse_csv_bytes
 
 # Every dataset that is not a grid — climate_normals included, which used to be
 # appended by hand because it converts to Parquet without being loadable.

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -19,11 +19,9 @@ from foehn.collections import (
     GRANULARITIES,
     TIME_SLICES,
 )
-from foehn.convert import (
-    decode_meteoswiss_csv,
-)
 from foehn.fetch import DEFAULT_WORKERS, default_fetcher
 from foehn.grids import sanitize_noncf_time_units, write_zarr
+from foehn.meteocsv import decode_meteoswiss_csv
 from foehn.readers import Filters
 from foehn.workspace import Workspace
 

--- a/src/foehn/client.py
+++ b/src/foehn/client.py
@@ -8,7 +8,7 @@ import zipfile
 from datetime import UTC, datetime
 from pathlib import Path
 
-from foehn.assets import Asset, assets_of, collection_assets, latest_run_of, select
+from foehn.assets import assets_of, collection_assets, latest_run_of, select
 from foehn.collections import CLIMATE_NORMALS_ZIP_URL, COLLECTIONS
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
 from foehn.transfer import (
@@ -225,35 +225,6 @@ def download_metadata(
         write=csv_to_disk,
         label="metadata file",
     )
-
-
-# --- Skip rules ---
-
-
-def already_current(asset: Asset, filepath: Path) -> bool:
-    """A :data:`~foehn.transfer.SkipRule`: is the local copy of *asset* up to date?
-
-    Handles MeteoSwiss's in-place overwrites — e.g. CombiPrecip reanalysis
-    (CPCH) replaces the original CPC hourly file with the same filename
-    ~8 days later. A plain exists() check would leave the stale version
-    on disk; comparing the STAC "updated" timestamp against local mtime
-    picks up those server-side updates.
-    """
-    if not filepath.exists():
-        return False
-    if not asset.updated:
-        return True
-    try:
-        remote_dt = datetime.fromisoformat(asset.updated)
-        local_dt = datetime.fromtimestamp(filepath.stat().st_mtime, tz=UTC)
-    except (ValueError, OSError):
-        return True
-    return remote_dt <= local_dt
-
-
-def exists(_asset: Asset, filepath: Path) -> bool:
-    """A :data:`~foehn.transfer.SkipRule` for static assets: fetch each one once."""
-    return filepath.exists()
 
 
 # --- ZIP safety (zip-slip + decompression-bomb guards) ---

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -1,11 +1,14 @@
-"""Convert downloaded CSVs and TXTs to Parquet using Polars."""
+"""Bronze → Parquet: one output per group, written atomically, skipped when current.
+
+The convert stage of the pipeline, and nothing else. How a MeteoSwiss CSV is
+decoded, typed and grouped is :mod:`foehn.meteocsv`, which this module imports
+and the load path imports separately — the two stages share upstream conventions
+without either owning the other.
+"""
 
 from __future__ import annotations
 
-import codecs
-import io
 import logging
-import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,215 +16,18 @@ from typing import Literal
 
 import polars as pl
 
-from foehn.collections import COLLECTIONS, NO_GRANULARITY_KINDS, kind
+from foehn.meteocsv import (
+    add_forecast_local_timestamp,
+    add_indoor_columns,
+    column_from_dtype_error,
+    group_csv_files,
+    load_metadata_types,
+    parse_indoor_filename,
+    scan_climate_scenarios_csv,
+)
 from foehn.workspace import Workspace
 
 logger = logging.getLogger(__name__)
-
-_COL_RE = re.compile(r"at column '([^']+)'")
-
-
-def decode_meteoswiss_csv(content: bytes) -> str:
-    """Decode MeteoSwiss CSV bytes to text.
-
-    MeteoSwiss CSVs are usually UTF-8 (often with a BOM) but some legacy files
-    are Windows-1252. Try UTF-8 (BOM-aware) first, falling back to Windows-1252.
-    The fallback replaces the five bytes cp1252 leaves unmapped (0x81, 0x8D,
-    0x8F, 0x90, 0x9D) rather than raising, so the decode is total.
-    """
-    try:
-        return content.decode("utf-8-sig")
-    except UnicodeDecodeError:
-        return content.decode("windows-1252", errors="replace")
-
-
-_UTF8_BOM = b"\xef\xbb\xbf"
-
-# Validate in 1 MiB steps rather than decoding the whole buffer: the point is to
-# confirm the bytes are UTF-8 without ever materialising the file as a str.
-_UTF8_VALIDATE_STEP = 1 << 20
-
-
-def utf8_meteoswiss_csv(content: bytes) -> bytes | memoryview:
-    """Return *content* as UTF-8 bytes, re-encoding only when it isn't already.
-
-    :func:`decode_meteoswiss_csv` exists to produce text. Callers that only want
-    bytes to hand to Polars were round-tripping through it — bytes → str →
-    bytes — which keeps three copies of the payload alive at once. On an 80 MB
-    CSV that measured 161 MB of transient allocation per file, and the download
-    paths run eight of these concurrently.
-
-    MeteoSwiss CSVs are usually UTF-8 (often BOM-prefixed), so the common path
-    validates incrementally and hands back a ``memoryview`` over the caller's
-    original buffer: no copy, and the BOM is skipped by slicing rather than by
-    building a new bytes object. Only genuine Windows-1252 files pay for a
-    re-encode. The returned view borrows *content*, which must outlive it.
-    """
-    view = memoryview(content)
-    has_bom = content.startswith(_UTF8_BOM)
-    if has_bom:
-        view = view[len(_UTF8_BOM) :]
-
-    decoder = codecs.getincrementaldecoder("utf-8")()
-    try:
-        for i in range(0, len(view), _UTF8_VALIDATE_STEP):
-            decoder.decode(view[i : i + _UTF8_VALIDATE_STEP])
-        decoder.decode(b"", final=True)
-    except UnicodeDecodeError:
-        return content.decode("windows-1252", errors="replace").encode("utf-8")
-    # Hand back the caller's own bytes when there is nothing to strip. A
-    # memoryview is only needed to skip a BOM without copying, and it is the
-    # costlier return: io.BytesIO(bytes) shares the buffer, but wrapping a
-    # memoryview copies the whole payload.
-    return content if not has_bom else view
-
-
-_DTYPE_MAP: dict[str, type[pl.DataType]] = {
-    "float": pl.Float64,
-    "integer": pl.Int64,
-}
-
-
-def parse_metadata_types(content: bytes | str) -> dict[str, type[pl.DataType]]:
-    """Build a parameter→Polars dtype mapping from metadata CSV content.
-
-    Works with both raw bytes (in-memory) and string content.
-    Returns an empty dict if the expected columns are missing.
-
-    Public because the in-memory load path crosses this seam for it: schema
-    inference from a collection's ``_meta_parameters.csv`` is one rule, and a
-    name-mangled import was hiding that it is part of this module's interface.
-    """
-    try:
-        if isinstance(content, str):
-            content = content.encode("utf-8")
-        meta = pl.read_csv(io.BytesIO(content), separator=";", infer_schema_length=0)
-    except Exception:
-        return {}
-
-    if "parameter_shortname" not in meta.columns or "parameter_datatype" not in meta.columns:
-        return {}
-
-    type_map: dict[str, type[pl.DataType]] = {}
-    for row in meta.select("parameter_shortname", "parameter_datatype").iter_rows():
-        shortname, datatype = row
-        if shortname and datatype:
-            dtype = _DTYPE_MAP.get(datatype.strip().lower())
-            if dtype is not None:
-                type_map[shortname] = dtype
-    return type_map
-
-
-def load_metadata_types(csv_dir: Path) -> dict[str, type[pl.DataType]]:
-    """Build a parameter→Polars dtype mapping from a *_meta_parameters.csv file.
-
-    Returns an empty dict if no metadata file is found or if the expected
-    columns (``parameter_shortname``, ``parameter_datatype``) are missing.
-
-    The file-based counterpart to :func:`parse_metadata_types`, and public for
-    the same reason: the Databricks ingest script reads it across this seam.
-    """
-    # sorted(): glob order is filesystem-dependent, so an unsorted [0] picks
-    # arbitrarily when a collection ships more than one metadata file.
-    meta_files = sorted(csv_dir.glob("*_meta_parameters.csv"))
-    if not meta_files:
-        return {}
-
-    meta_path = meta_files[0]
-    try:
-        return parse_metadata_types(meta_path.read_bytes())
-    except Exception:
-        return {}
-
-
-def parse_csv_bytes(
-    content: bytes | memoryview,
-    metadata_types: dict[str, type[pl.DataType]] | None = None,
-    wanted_columns: set[str] | None = None,
-) -> pl.DataFrame:
-    """Parse CSV bytes into a Polars DataFrame, applying metadata type overrides.
-
-    Args:
-        content: Raw CSV bytes (UTF-8 encoded); a memoryview is accepted so
-            callers can pass a zero-copy view from ``utf8_meteoswiss_csv``.
-        metadata_types: Optional parameter→dtype mapping from metadata.
-        wanted_columns: Only parse these columns (intersected with the file's own
-            header, so a station missing one is not an error — the diagonal concat
-            fills it with nulls exactly as before). A station file is ~42 columns
-            and a typical query wants two or three, so skipping the rest cuts both
-            parse time and, far more importantly, the frame retained per station
-            while the whole matched set is assembled.
-
-    Returns:
-        Parsed Polars DataFrame.
-    """
-    # Polars reads a bytes object without copying it and strips any UTF-8 BOM
-    # itself; a memoryview has to be materialised once, here rather than per read.
-    data = content if isinstance(content, bytes) else bytes(content)
-
-    header: list[str] | None = None
-    if metadata_types or wanted_columns:
-        try:
-            # Parse the header line alone — wrapping the whole payload to read one
-            # line costs a copy of the entire file.
-            end = data.find(b"\n")
-            header = pl.read_csv(
-                data[: end + 1] if end != -1 else data, separator=";", n_rows=0, infer_schema_length=0
-            ).columns
-        except Exception as exc:
-            logger.debug("Could not read CSV header (%s) — parsing every column, inferring types", exc)
-
-    # Intersect in header order. Falling back to "everything" when nothing matches
-    # keeps read_csv(columns=[]) — which is an error — off the table.
-    use_columns: list[str] | None = None
-    if wanted_columns and header is not None:
-        use_columns = [c for c in header if c in wanted_columns] or None
-
-    # Build per-file overrides by matching CSV columns to metadata types. Restricted
-    # to the columns actually being read: polars rejects an override naming a column
-    # that the projection excluded.
-    overrides: dict[str, type[pl.DataType]] = {}
-    if metadata_types and header is not None:
-        for col in use_columns if use_columns is not None else header:
-            if col in metadata_types:
-                overrides[col] = metadata_types[col]
-
-    try:
-        return pl.read_csv(
-            data,
-            separator=";",
-            infer_schema_length=100,
-            try_parse_dates=True,
-            schema_overrides=overrides or None,
-            columns=use_columns,
-        )
-    except (pl.exceptions.ComputeError, pl.exceptions.SchemaError) as e:
-        # Fallback: accumulate Float64 overrides for problematic columns.
-        last_err = e
-        while True:
-            m = _COL_RE.search(str(last_err))
-            # A column already forced to Float64 can't be widened further —
-            # bail out instead of retrying the same parse forever.
-            if not m or overrides.get(m.group(1)) == pl.Float64:
-                break
-            if use_columns is not None and m.group(1) not in use_columns:
-                break  # not a column we're reading; widening it would be rejected
-            overrides[m.group(1)] = pl.Float64
-            try:
-                return pl.read_csv(
-                    data,
-                    separator=";",
-                    infer_schema_length=100,
-                    try_parse_dates=True,
-                    schema_overrides=overrides,
-                    columns=use_columns,
-                )
-            except (pl.exceptions.ComputeError, pl.exceptions.SchemaError) as e2:
-                last_err = e2
-            except Exception:
-                raise
-        raise last_err from None
-
 
 # The two codecs the converters below actually use. Narrower than polars'
 # ParquetCompression on purpose: a bare ``str`` is wider than the literal
@@ -262,12 +68,6 @@ class ConversionGroup:
 
 
 ConvertOne = Callable[[ConversionGroup], int]
-"""Build ``group.out_path`` from ``group.sources``; return source-level failures tolerated.
-
-A converter that skips an unreadable source file and writes the rest reports how
-many it skipped, so the caller's exit code still reflects them. Raising instead
-means the whole group failed.
-"""
 
 
 def _is_up_to_date(group: ConversionGroup) -> bool:
@@ -315,60 +115,6 @@ def run_conversions(groups: Iterable[ConversionGroup], convert_one: ConvertOne, 
     return failed
 
 
-def add_forecast_local_timestamp(frame):
-    """Add a parsed reference_timestamp from forecast_local's compact Date column.
-
-    forecast_local CSVs carry ``point_id;point_type_id;Date;<param>`` where Date
-    is ``YYYYMMDDHHMM`` (e.g. 202605202100) and there is no reference_timestamp.
-    Works on both a LazyFrame and a DataFrame; a no-op if Date is absent or a
-    reference_timestamp already exists.
-    """
-    cols = frame.collect_schema().names() if isinstance(frame, pl.LazyFrame) else frame.columns
-    if "Date" not in cols or "reference_timestamp" in cols:
-        return frame
-    return frame.with_columns(
-        pl.col("Date").cast(pl.Utf8).str.to_datetime("%Y%m%d%H%M", strict=False).alias("reference_timestamp")
-    )
-
-
-def group_csv_files(csv_dir: Path, collection_key: str) -> dict[tuple[str, ...], list[Path]]:
-    """Group a collection's data CSVs by (frequency, time_slice).
-
-    MeteoSwiss names standard CSV assets
-    ``ogd-{key}_{station}_{granularity}[_{timeslice}].csv``, so the group key is
-    read out of the filename: ``ogd-smn_ber_d_recent.csv`` → ``("d", "recent")``.
-    Metadata CSVs are excluded, and collections whose filenames carry no
-    granularity segment collapse into a single unkeyed group.
-
-    Shared with the Delta ingestion script, which builds one table per group and
-    must agree with the Parquet converter on where the boundaries are — these
-    are upstream naming rules, and two copies of them drift.
-    """
-    csv_files = [f for f in sorted(csv_dir.glob("*.csv")) if "_meta_" not in f.name]
-    groups: dict[tuple[str, ...], list[Path]] = {}
-
-    # No granularity in the filename at all (forecast_local's vnut12.lssw.* names,
-    # climate_scenarios). Returning early also avoids slicing off a prefix these
-    # names do not carry, which would chop arbitrary characters off the stem.
-    if kind(collection_key) in NO_GRANULARITY_KINDS:
-        if csv_files:
-            groups[()] = csv_files
-        return groups
-
-    # Derive the filename prefix from the collection ID (e.g. "ogd-smn").
-    prefix = COLLECTIONS[collection_key].rsplit(".", 1)[-1]
-    for csv_path in csv_files:
-        suffix_part = csv_path.stem[len(prefix) + 1 :]  # e.g. "ber_d_recent"
-        parts = suffix_part.split("_")
-        if len(parts) > 2:
-            group_key = (parts[1], parts[2])  # (frequency, time_slice)
-        else:
-            group_key = (parts[1],) if len(parts) > 1 else ()  # (frequency,)
-        groups.setdefault(group_key, []).append(csv_path)
-
-    return groups
-
-
 def _group_out_name(collection_key: str, group_key: tuple[str, ...]) -> str:
     """Output name for one group: smn_d_recent.parquet, smn_d.parquet, or smn.parquet."""
     return f"{collection_key}_{'_'.join(group_key)}.parquet" if group_key else f"{collection_key}.parquet"
@@ -406,10 +152,9 @@ def _convert_standard_group(collection_key: str, metadata_types: dict[str, type[
                 _write_parquet_atomic(combined, group.out_path)
                 break
             except (pl.exceptions.ComputeError, pl.exceptions.SchemaError) as e:
-                m = _COL_RE.search(str(e))
-                if not m:
+                col = column_from_dtype_error(str(e))
+                if col is None:
                     raise
-                col = m.group(1)
                 # If we already forced this column to Float64 and it still
                 # fails, we can't recover by widening dtype further.
                 if overrides.get(col) == pl.Float64:
@@ -456,39 +201,6 @@ def convert_to_parquet(dataset: str, workspace: Workspace) -> int:
     return run_conversions(groups, _convert_standard_group(dataset, metadata_types), label=dataset)
 
 
-_INDOOR_TIME_COLS = ["time.yy", "time.mm", "time.dd", "time.hh"]
-
-
-def parse_indoor_filename(stem: str) -> tuple[str, str, str, str] | None:
-    """Parse an indoor scenario filename into (station, period, scenario, variant).
-
-    Data files are ``{station}_{period}_{scenario}_{variant}`` with a 4-digit
-    year as the period. Returns None for anything else (e.g. the archive's
-    metadata CSV), so callers can skip non-data files.
-    """
-    parts = stem.split("_")
-    if len(parts) < 4 or not parts[1].isdigit():
-        return None
-    return parts[0], parts[1], parts[2], "_".join(parts[3:])
-
-
-def add_indoor_columns(frame, station: str, period: str, scenario: str, variant: str):
-    """Add reference_timestamp + filename-derived columns and drop the raw time
-    columns. Works on both a LazyFrame (scan_csv) and a DataFrame (read_csv)."""
-    return frame.with_columns(
-        pl.datetime(
-            pl.col("time.yy"),
-            pl.col("time.mm"),
-            pl.col("time.dd"),
-            hour=pl.col("time.hh"),
-        ).alias("reference_timestamp"),
-        pl.lit(station).alias("station_abbr"),
-        pl.lit(period).alias("period"),
-        pl.lit(scenario).alias("scenario"),
-        pl.lit(variant).alias("variant"),
-    ).drop(_INDOOR_TIME_COLS)
-
-
 def convert_indoor_to_parquet(dataset: str, workspace: Workspace) -> int:
     """Convert extracted indoor climate scenario CSVs to a single Parquet file.
 
@@ -529,101 +241,6 @@ def convert_indoor_to_parquet(dataset: str, workspace: Workspace) -> int:
 
     out_path = workspace.parquet(dataset) / f"{dataset}.parquet"
     return run_conversions([ConversionGroup(out_path, csv_files)], convert_one, label=dataset)
-
-
-_CS_HEADER_PREFIX = "DATE;"
-
-
-def parse_climate_scenarios_filename(filename: str) -> tuple[str, str, str]:
-    """Parse a climate-scenario filename into (station, variable, gwl).
-
-    Files are named ``ogd-climate-scenarios-ch2025_{station}_{variable}_{gwl}``.
-    """
-    stem = filename.rsplit("/", 1)[-1]
-    stem = stem.removesuffix(".csv")
-    parts = stem.split("_")
-    if len(parts) < 3:
-        raise ValueError(
-            f"Unexpected climate-scenario filename {filename!r}: expected "
-            "'..._{station}_{variable}_{gwl}', cannot extract station/variable/gwl."
-        )
-    return parts[-3], parts[-2], parts[-1]
-
-
-def add_climate_scenarios_columns(frame, station: str, variable: str, gwl: str):
-    """Add filename-derived columns and move the key columns to the front.
-
-    Works on both a LazyFrame (scan_csv) and a DataFrame (read_csv)."""
-    frame = frame.rename({"DATE": "date"}).with_columns(
-        pl.lit(station).alias("station_abbr"),
-        pl.lit(variable).alias("variable"),
-        pl.lit(gwl).alias("gwl"),
-    )
-    cols = frame.collect_schema().names() if isinstance(frame, pl.LazyFrame) else frame.columns
-    front = ["station_abbr", "variable", "gwl", "date"]
-    return frame.select(front + [c for c in cols if c not in front])
-
-
-def parse_climate_scenarios_csv(content: bytes | str, filename: str) -> pl.DataFrame:
-    """Parse a CH2025 climate-scenario CSV into a wide model table.
-
-    These files carry a multi-row ``KEY;VALUE`` metadata preamble before the
-    real ``DATE;<model>;<model>;...`` header. We skip the preamble, read the
-    table, and tag rows with station/variable/gwl parsed from the filename
-    (``ogd-climate-scenarios-ch2025_{station}_{variable}_{gwl}``). The DATE
-    column is kept as a string because it encodes a nominal 30-year period
-    (0001-01-01 … 0030-12-31 on a 365-day calendar), not real calendar dates.
-
-    This is the in-memory path (used when streaming a download); the file-based
-    converter uses :func:`scan_climate_scenarios_csv` instead.
-    """
-    text = content.decode("utf-8-sig", errors="replace") if isinstance(content, bytes) else content
-    lines = text.splitlines()
-    header_idx = next((i for i, line in enumerate(lines) if line.startswith(_CS_HEADER_PREFIX)), None)
-    if header_idx is None:
-        raise ValueError(f"No 'DATE;' data header found in {filename!r}")
-
-    station, variable, gwl = parse_climate_scenarios_filename(filename)
-
-    table = "\n".join(lines[header_idx:])
-    df = pl.read_csv(
-        io.BytesIO(table.encode("utf-8")),
-        separator=";",
-        infer_schema_length=20_000,
-        truncate_ragged_lines=True,
-    )
-    return add_climate_scenarios_columns(df, station, variable, gwl)
-
-
-def _climate_scenarios_preamble_lines(path: Path) -> int:
-    """Count the metadata preamble lines before the ``DATE;`` header.
-
-    Reads the file line by line and stops at the header, so a file of any size
-    costs only its preamble — the whole point of not slurping it into memory.
-    """
-    with path.open("rb") as fh:
-        for i, raw in enumerate(fh):
-            if raw.decode("utf-8-sig", errors="replace").startswith(_CS_HEADER_PREFIX):
-                return i
-    raise ValueError(f"No 'DATE;' data header found in {path.name!r}")
-
-
-def scan_climate_scenarios_csv(path: Path) -> pl.LazyFrame:
-    """Lazily scan a CH2025 climate-scenario CSV, skipping its metadata preamble.
-
-    ``skip_lines`` (not ``skip_rows``) matches how the preamble is counted: raw
-    newlines, ignoring CSV quoting, so a stray quote in a metadata value can't
-    shift the header offset.
-    """
-    station, variable, gwl = parse_climate_scenarios_filename(path.name)
-    lf = pl.scan_csv(
-        path,
-        separator=";",
-        skip_lines=_climate_scenarios_preamble_lines(path),
-        infer_schema_length=20_000,
-        truncate_ragged_lines=True,
-    )
-    return add_climate_scenarios_columns(lf, station, variable, gwl)
 
 
 def convert_preamble_to_parquet(dataset: str, workspace: Workspace) -> int:

--- a/src/foehn/grids.py
+++ b/src/foehn/grids.py
@@ -54,7 +54,7 @@ from typing import TYPE_CHECKING, Protocol
 from foehn.assets import Asset, assets_of, collection_assets, other_extensions
 from foehn.collections import COLLECTION_META, COLLECTIONS
 from foehn.fetch import Fetcher, FetchError
-from foehn.transfer import fetch_all
+from foehn.transfer import exists, fetch_all
 from foehn.workspace import Workspace
 
 logger = logging.getLogger(__name__)
@@ -283,11 +283,6 @@ def _raise_if_too_many(dataset: str, match: str | None, names: list[str], max_fi
     )
 
 
-def _exists(_asset: Asset, filepath: Path) -> bool:
-    """A :data:`~foehn.transfer.SkipRule`: a grid file already on disk is never refetched."""
-    return filepath.exists()
-
-
 def _grid_assets(items: list[dict], suffixes: tuple[str, ...], match: str | None) -> tuple[list[Asset], set[str]]:
     """Pick the grid assets out of a STAC listing.
 
@@ -375,7 +370,7 @@ def ensure_grid_files(
         matched,
         out_dir,
         fetcher=fetcher,
-        skip=_exists,
+        skip=exists,
         on_error="raise",
         label="grid file",
     )

--- a/src/foehn/meteocsv.py
+++ b/src/foehn/meteocsv.py
@@ -1,0 +1,427 @@
+"""How MeteoSwiss writes a CSV, and everything foehn needs to read one back.
+
+The encoding fallback, the semicolon separator, the dtype overrides from a
+collection's ``_meta_parameters.csv``, the ``KEY;VALUE`` preamble, and the
+filename rules that say which station, granularity, scenario or forecast run a
+file holds. Upstream conventions, in one place, below every pipeline that reads
+them.
+
+Split out of ``foehn.convert``, which owned these *and* the Bronze → Parquet
+stage. Five modules imported that one: four of them — ``readers`` for the load
+path, ``transfer`` for one byte-level helper, ``api``, and the Databricks ingest
+script, which writes Delta and never produces a Parquet file — wanted only the
+conventions, and only ``registry`` wanted the Parquet stage. So the download
+engine depended on the Parquet converter, and so, through it, did the gridded
+read path. Nothing here knows what a Parquet file is; ``convert`` imports this
+module and not the other way round.
+"""
+
+from __future__ import annotations
+
+import codecs
+import io
+import logging
+import re
+from pathlib import Path
+
+import polars as pl
+
+from foehn.collections import COLLECTIONS, NO_GRANULARITY_KINDS, kind
+
+logger = logging.getLogger(__name__)
+
+# Polars names the offending column in its dtype errors. Both readers of a
+# MeteoSwiss CSV widen that column to Float64 and retry — the in-memory parse
+# here and the streaming convert in ``foehn.convert`` — so the pattern is stated
+# once, where the parsing rules live.
+_COL_RE = re.compile(r"at column '([^']+)'")
+
+
+def column_from_dtype_error(message: str) -> str | None:
+    """Return the column polars blamed in a dtype error, or None if it named none."""
+    found = _COL_RE.search(message)
+    return found.group(1) if found else None
+
+
+def decode_meteoswiss_csv(content: bytes) -> str:
+    """Decode MeteoSwiss CSV bytes to text.
+
+    MeteoSwiss CSVs are usually UTF-8 (often with a BOM) but some legacy files
+    are Windows-1252. Try UTF-8 (BOM-aware) first, falling back to Windows-1252.
+    The fallback replaces the five bytes cp1252 leaves unmapped (0x81, 0x8D,
+    0x8F, 0x90, 0x9D) rather than raising, so the decode is total.
+    """
+    try:
+        return content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return content.decode("windows-1252", errors="replace")
+
+
+_UTF8_BOM = b"\xef\xbb\xbf"
+
+# Validate in 1 MiB steps rather than decoding the whole buffer: the point is to
+# confirm the bytes are UTF-8 without ever materialising the file as a str.
+_UTF8_VALIDATE_STEP = 1 << 20
+
+
+def utf8_meteoswiss_csv(content: bytes) -> bytes | memoryview:
+    """Return *content* as UTF-8 bytes, re-encoding only when it isn't already.
+
+    :func:`decode_meteoswiss_csv` exists to produce text. Callers that only want
+    bytes to hand to Polars were round-tripping through it — bytes → str →
+    bytes — which keeps three copies of the payload alive at once. On an 80 MB
+    CSV that measured 161 MB of transient allocation per file, and the download
+    paths run eight of these concurrently.
+
+    MeteoSwiss CSVs are usually UTF-8 (often BOM-prefixed), so the common path
+    validates incrementally and hands back a ``memoryview`` over the caller's
+    original buffer: no copy, and the BOM is skipped by slicing rather than by
+    building a new bytes object. Only genuine Windows-1252 files pay for a
+    re-encode. The returned view borrows *content*, which must outlive it.
+    """
+    view = memoryview(content)
+    has_bom = content.startswith(_UTF8_BOM)
+    if has_bom:
+        view = view[len(_UTF8_BOM) :]
+
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    try:
+        for i in range(0, len(view), _UTF8_VALIDATE_STEP):
+            decoder.decode(view[i : i + _UTF8_VALIDATE_STEP])
+        decoder.decode(b"", final=True)
+    except UnicodeDecodeError:
+        return content.decode("windows-1252", errors="replace").encode("utf-8")
+    # Hand back the caller's own bytes when there is nothing to strip. A
+    # memoryview is only needed to skip a BOM without copying, and it is the
+    # costlier return: io.BytesIO(bytes) shares the buffer, but wrapping a
+    # memoryview copies the whole payload.
+    return content if not has_bom else view
+
+
+_DTYPE_MAP: dict[str, type[pl.DataType]] = {
+    "float": pl.Float64,
+    "integer": pl.Int64,
+}
+
+
+def parse_metadata_types(content: bytes | str) -> dict[str, type[pl.DataType]]:
+    """Build a parameter→Polars dtype mapping from metadata CSV content.
+
+    Works with both raw bytes (in-memory) and string content.
+    Returns an empty dict if the expected columns are missing.
+
+    Public because the in-memory load path crosses this seam for it: schema
+    inference from a collection's ``_meta_parameters.csv`` is one rule, and a
+    name-mangled import was hiding that it is part of this module's interface.
+    """
+    try:
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        meta = pl.read_csv(io.BytesIO(content), separator=";", infer_schema_length=0)
+    except Exception:
+        return {}
+
+    if "parameter_shortname" not in meta.columns or "parameter_datatype" not in meta.columns:
+        return {}
+
+    type_map: dict[str, type[pl.DataType]] = {}
+    for row in meta.select("parameter_shortname", "parameter_datatype").iter_rows():
+        shortname, datatype = row
+        if shortname and datatype:
+            dtype = _DTYPE_MAP.get(datatype.strip().lower())
+            if dtype is not None:
+                type_map[shortname] = dtype
+    return type_map
+
+
+def load_metadata_types(csv_dir: Path) -> dict[str, type[pl.DataType]]:
+    """Build a parameter→Polars dtype mapping from a *_meta_parameters.csv file.
+
+    Returns an empty dict if no metadata file is found or if the expected
+    columns (``parameter_shortname``, ``parameter_datatype``) are missing.
+
+    The file-based counterpart to :func:`parse_metadata_types`, and public for
+    the same reason: the Databricks ingest script reads it across this seam.
+    """
+    # sorted(): glob order is filesystem-dependent, so an unsorted [0] picks
+    # arbitrarily when a collection ships more than one metadata file.
+    meta_files = sorted(csv_dir.glob("*_meta_parameters.csv"))
+    if not meta_files:
+        return {}
+
+    meta_path = meta_files[0]
+    try:
+        return parse_metadata_types(meta_path.read_bytes())
+    except Exception:
+        return {}
+
+
+def parse_csv_bytes(
+    content: bytes | memoryview,
+    metadata_types: dict[str, type[pl.DataType]] | None = None,
+    wanted_columns: set[str] | None = None,
+) -> pl.DataFrame:
+    """Parse CSV bytes into a Polars DataFrame, applying metadata type overrides.
+
+    Args:
+        content: Raw CSV bytes (UTF-8 encoded); a memoryview is accepted so
+            callers can pass a zero-copy view from ``utf8_meteoswiss_csv``.
+        metadata_types: Optional parameter→dtype mapping from metadata.
+        wanted_columns: Only parse these columns (intersected with the file's own
+            header, so a station missing one is not an error — the diagonal concat
+            fills it with nulls exactly as before). A station file is ~42 columns
+            and a typical query wants two or three, so skipping the rest cuts both
+            parse time and, far more importantly, the frame retained per station
+            while the whole matched set is assembled.
+
+    Returns:
+        Parsed Polars DataFrame.
+    """
+    # Polars reads a bytes object without copying it and strips any UTF-8 BOM
+    # itself; a memoryview has to be materialised once, here rather than per read.
+    data = content if isinstance(content, bytes) else bytes(content)
+
+    header: list[str] | None = None
+    if metadata_types or wanted_columns:
+        try:
+            # Parse the header line alone — wrapping the whole payload to read one
+            # line costs a copy of the entire file.
+            end = data.find(b"\n")
+            header = pl.read_csv(
+                data[: end + 1] if end != -1 else data, separator=";", n_rows=0, infer_schema_length=0
+            ).columns
+        except Exception as exc:
+            logger.debug("Could not read CSV header (%s) — parsing every column, inferring types", exc)
+
+    # Intersect in header order. Falling back to "everything" when nothing matches
+    # keeps read_csv(columns=[]) — which is an error — off the table.
+    use_columns: list[str] | None = None
+    if wanted_columns and header is not None:
+        use_columns = [c for c in header if c in wanted_columns] or None
+
+    # Build per-file overrides by matching CSV columns to metadata types. Restricted
+    # to the columns actually being read: polars rejects an override naming a column
+    # that the projection excluded.
+    overrides: dict[str, type[pl.DataType]] = {}
+    if metadata_types and header is not None:
+        for col in use_columns if use_columns is not None else header:
+            if col in metadata_types:
+                overrides[col] = metadata_types[col]
+
+    try:
+        return pl.read_csv(
+            data,
+            separator=";",
+            infer_schema_length=100,
+            try_parse_dates=True,
+            schema_overrides=overrides or None,
+            columns=use_columns,
+        )
+    except (pl.exceptions.ComputeError, pl.exceptions.SchemaError) as e:
+        # Fallback: accumulate Float64 overrides for problematic columns.
+        last_err = e
+        while True:
+            col = column_from_dtype_error(str(last_err))
+            # A column already forced to Float64 can't be widened further —
+            # bail out instead of retrying the same parse forever.
+            if col is None or overrides.get(col) == pl.Float64:
+                break
+            if use_columns is not None and col not in use_columns:
+                break  # not a column we're reading; widening it would be rejected
+            overrides[col] = pl.Float64
+            try:
+                return pl.read_csv(
+                    data,
+                    separator=";",
+                    infer_schema_length=100,
+                    try_parse_dates=True,
+                    schema_overrides=overrides,
+                    columns=use_columns,
+                )
+            except (pl.exceptions.ComputeError, pl.exceptions.SchemaError) as e2:
+                last_err = e2
+            except Exception:
+                raise
+        raise last_err from None
+
+
+def add_forecast_local_timestamp(frame):
+    """Add a parsed reference_timestamp from forecast_local's compact Date column.
+
+    forecast_local CSVs carry ``point_id;point_type_id;Date;<param>`` where Date
+    is ``YYYYMMDDHHMM`` (e.g. 202605202100) and there is no reference_timestamp.
+    Works on both a LazyFrame and a DataFrame; a no-op if Date is absent or a
+    reference_timestamp already exists.
+    """
+    cols = frame.collect_schema().names() if isinstance(frame, pl.LazyFrame) else frame.columns
+    if "Date" not in cols or "reference_timestamp" in cols:
+        return frame
+    return frame.with_columns(
+        pl.col("Date").cast(pl.Utf8).str.to_datetime("%Y%m%d%H%M", strict=False).alias("reference_timestamp")
+    )
+
+
+def group_csv_files(csv_dir: Path, collection_key: str) -> dict[tuple[str, ...], list[Path]]:
+    """Group a collection's data CSVs by (frequency, time_slice).
+
+    MeteoSwiss names standard CSV assets
+    ``ogd-{key}_{station}_{granularity}[_{timeslice}].csv``, so the group key is
+    read out of the filename: ``ogd-smn_ber_d_recent.csv`` → ``("d", "recent")``.
+    Metadata CSVs are excluded, and collections whose filenames carry no
+    granularity segment collapse into a single unkeyed group.
+
+    Shared with the Delta ingestion script, which builds one table per group and
+    must agree with the Parquet converter on where the boundaries are — these
+    are upstream naming rules, and two copies of them drift.
+    """
+    csv_files = [f for f in sorted(csv_dir.glob("*.csv")) if "_meta_" not in f.name]
+    groups: dict[tuple[str, ...], list[Path]] = {}
+
+    # No granularity in the filename at all (forecast_local's vnut12.lssw.* names,
+    # climate_scenarios). Returning early also avoids slicing off a prefix these
+    # names do not carry, which would chop arbitrary characters off the stem.
+    if kind(collection_key) in NO_GRANULARITY_KINDS:
+        if csv_files:
+            groups[()] = csv_files
+        return groups
+
+    # Derive the filename prefix from the collection ID (e.g. "ogd-smn").
+    prefix = COLLECTIONS[collection_key].rsplit(".", 1)[-1]
+    for csv_path in csv_files:
+        suffix_part = csv_path.stem[len(prefix) + 1 :]  # e.g. "ber_d_recent"
+        parts = suffix_part.split("_")
+        if len(parts) > 2:
+            group_key = (parts[1], parts[2])  # (frequency, time_slice)
+        else:
+            group_key = (parts[1],) if len(parts) > 1 else ()  # (frequency,)
+        groups.setdefault(group_key, []).append(csv_path)
+
+    return groups
+
+
+_INDOOR_TIME_COLS = ["time.yy", "time.mm", "time.dd", "time.hh"]
+
+
+def parse_indoor_filename(stem: str) -> tuple[str, str, str, str] | None:
+    """Parse an indoor scenario filename into (station, period, scenario, variant).
+
+    Data files are ``{station}_{period}_{scenario}_{variant}`` with a 4-digit
+    year as the period. Returns None for anything else (e.g. the archive's
+    metadata CSV), so callers can skip non-data files.
+    """
+    parts = stem.split("_")
+    if len(parts) < 4 or not parts[1].isdigit():
+        return None
+    return parts[0], parts[1], parts[2], "_".join(parts[3:])
+
+
+def add_indoor_columns(frame, station: str, period: str, scenario: str, variant: str):
+    """Add reference_timestamp + filename-derived columns and drop the raw time
+    columns. Works on both a LazyFrame (scan_csv) and a DataFrame (read_csv)."""
+    return frame.with_columns(
+        pl.datetime(
+            pl.col("time.yy"),
+            pl.col("time.mm"),
+            pl.col("time.dd"),
+            hour=pl.col("time.hh"),
+        ).alias("reference_timestamp"),
+        pl.lit(station).alias("station_abbr"),
+        pl.lit(period).alias("period"),
+        pl.lit(scenario).alias("scenario"),
+        pl.lit(variant).alias("variant"),
+    ).drop(_INDOOR_TIME_COLS)
+
+
+_CS_HEADER_PREFIX = "DATE;"
+
+
+def parse_climate_scenarios_filename(filename: str) -> tuple[str, str, str]:
+    """Parse a climate-scenario filename into (station, variable, gwl).
+
+    Files are named ``ogd-climate-scenarios-ch2025_{station}_{variable}_{gwl}``.
+    """
+    stem = filename.rsplit("/", 1)[-1]
+    stem = stem.removesuffix(".csv")
+    parts = stem.split("_")
+    if len(parts) < 3:
+        raise ValueError(
+            f"Unexpected climate-scenario filename {filename!r}: expected "
+            "'..._{station}_{variable}_{gwl}', cannot extract station/variable/gwl."
+        )
+    return parts[-3], parts[-2], parts[-1]
+
+
+def add_climate_scenarios_columns(frame, station: str, variable: str, gwl: str):
+    """Add filename-derived columns and move the key columns to the front.
+
+    Works on both a LazyFrame (scan_csv) and a DataFrame (read_csv)."""
+    frame = frame.rename({"DATE": "date"}).with_columns(
+        pl.lit(station).alias("station_abbr"),
+        pl.lit(variable).alias("variable"),
+        pl.lit(gwl).alias("gwl"),
+    )
+    cols = frame.collect_schema().names() if isinstance(frame, pl.LazyFrame) else frame.columns
+    front = ["station_abbr", "variable", "gwl", "date"]
+    return frame.select(front + [c for c in cols if c not in front])
+
+
+def parse_climate_scenarios_csv(content: bytes | str, filename: str) -> pl.DataFrame:
+    """Parse a CH2025 climate-scenario CSV into a wide model table.
+
+    These files carry a multi-row ``KEY;VALUE`` metadata preamble before the
+    real ``DATE;<model>;<model>;...`` header. We skip the preamble, read the
+    table, and tag rows with station/variable/gwl parsed from the filename
+    (``ogd-climate-scenarios-ch2025_{station}_{variable}_{gwl}``). The DATE
+    column is kept as a string because it encodes a nominal 30-year period
+    (0001-01-01 … 0030-12-31 on a 365-day calendar), not real calendar dates.
+
+    This is the in-memory path (used when streaming a download); the file-based
+    converter uses :func:`scan_climate_scenarios_csv` instead.
+    """
+    text = content.decode("utf-8-sig", errors="replace") if isinstance(content, bytes) else content
+    lines = text.splitlines()
+    header_idx = next((i for i, line in enumerate(lines) if line.startswith(_CS_HEADER_PREFIX)), None)
+    if header_idx is None:
+        raise ValueError(f"No 'DATE;' data header found in {filename!r}")
+
+    station, variable, gwl = parse_climate_scenarios_filename(filename)
+
+    table = "\n".join(lines[header_idx:])
+    df = pl.read_csv(
+        io.BytesIO(table.encode("utf-8")),
+        separator=";",
+        infer_schema_length=20_000,
+        truncate_ragged_lines=True,
+    )
+    return add_climate_scenarios_columns(df, station, variable, gwl)
+
+
+def _climate_scenarios_preamble_lines(path: Path) -> int:
+    """Count the metadata preamble lines before the ``DATE;`` header.
+
+    Reads the file line by line and stops at the header, so a file of any size
+    costs only its preamble — the whole point of not slurping it into memory.
+    """
+    with path.open("rb") as fh:
+        for i, raw in enumerate(fh):
+            if raw.decode("utf-8-sig", errors="replace").startswith(_CS_HEADER_PREFIX):
+                return i
+    raise ValueError(f"No 'DATE;' data header found in {path.name!r}")
+
+
+def scan_climate_scenarios_csv(path: Path) -> pl.LazyFrame:
+    """Lazily scan a CH2025 climate-scenario CSV, skipping its metadata preamble.
+
+    ``skip_lines`` (not ``skip_rows``) matches how the preamble is counted: raw
+    newlines, ignoring CSV quoting, so a stray quote in a metadata value can't
+    shift the header offset.
+    """
+    station, variable, gwl = parse_climate_scenarios_filename(path.name)
+    lf = pl.scan_csv(
+        path,
+        separator=";",
+        skip_lines=_climate_scenarios_preamble_lines(path),
+        infer_schema_length=20_000,
+        truncate_ragged_lines=True,
+    )
+    return add_climate_scenarios_columns(lf, station, variable, gwl)

--- a/src/foehn/readers.py
+++ b/src/foehn/readers.py
@@ -3,7 +3,7 @@
 ``download`` and ``convert`` route through :mod:`foehn.registry`; loading used to
 route through an if-ladder in ``api`` instead, because hoisting the readers into
 the registry would have inverted ``registry → api``. The fix was not to hoist but
-to drop: these readers depend on ``assets``, ``client``, ``convert`` and
+to drop: these readers depend on ``assets``, ``client``, ``meteocsv`` and
 ``fetch``, never on ``api``, so they sit *below* the registry and
 :class:`~foehn.registry.KindSpec` can carry a ``load`` adapter beside its
 ``download`` and ``convert`` ones. All three pipeline stages now route the
@@ -33,7 +33,8 @@ from foehn._urls import asset_filename
 from foehn.assets import assets_of, collection_assets, hrefs, select
 from foehn.client import check_zip_size
 from foehn.collections import COLLECTIONS, DatasetKind, kind
-from foehn.convert import (
+from foehn.fetch import DEFAULT_WORKERS, Fetcher
+from foehn.meteocsv import (
     add_forecast_local_timestamp,
     add_indoor_columns,
     decode_meteoswiss_csv,
@@ -43,7 +44,6 @@ from foehn.convert import (
     parse_metadata_types,
     utf8_meteoswiss_csv,
 )
-from foehn.fetch import DEFAULT_WORKERS, Fetcher
 
 # A ``date_to`` of exactly "YYYY-MM-DD" names a whole day, not its midnight.
 _BARE_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")

--- a/src/foehn/registry.py
+++ b/src/foehn/registry.py
@@ -21,10 +21,8 @@ from typing import TYPE_CHECKING, Protocol
 
 from foehn.client import (
     DownloadResult,
-    already_current,
     download_indoor_zip,
     download_normals_zip,
-    exists,
     stac_download,
 )
 from foehn.collections import COLLECTION_META, COLLECTIONS, KIND_OF, DatasetKind, kind
@@ -48,7 +46,7 @@ from foehn.grids import (
     require_radar,
     select_variables,
 )
-from foehn.transfer import csv_to_disk
+from foehn.transfer import already_current, csv_to_disk, exists
 
 if TYPE_CHECKING:
     import polars as pl

--- a/src/foehn/transfer.py
+++ b/src/foehn/transfer.py
@@ -25,12 +25,13 @@ import logging
 from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
 from foehn.assets import Asset
-from foehn.convert import utf8_meteoswiss_csv
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
+from foehn.meteocsv import utf8_meteoswiss_csv
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,37 @@ Writer = Callable[[Fetcher, Asset, Path, str | None], WriteResult]
 
 SkipRule = Callable[[Asset, Path], bool]
 """``(asset, destination) -> skip it?``. Runs on the main thread, before anything is queued."""
+
+
+def exists(_asset: Asset, filepath: Path) -> bool:
+    """A :data:`SkipRule` for static assets: fetch each one once.
+
+    Lives here rather than with either caller: it was defined identically in the
+    download paths and in the gridded read path, which is one rule and two places
+    for it to change.
+    """
+    return filepath.exists()
+
+
+def already_current(asset: Asset, filepath: Path) -> bool:
+    """A :data:`SkipRule`: is the local copy of *asset* up to date?
+
+    Handles MeteoSwiss's in-place overwrites — e.g. CombiPrecip reanalysis
+    (CPCH) replaces the original CPC hourly file with the same filename
+    ~8 days later. A plain :func:`exists` check would leave the stale version
+    on disk; comparing the STAC "updated" timestamp against local mtime
+    picks up those server-side updates.
+    """
+    if not filepath.exists():
+        return False
+    if not asset.updated:
+        return True
+    try:
+        remote_dt = datetime.fromisoformat(asset.updated)
+        local_dt = datetime.fromtimestamp(filepath.stat().st_mtime, tz=UTC)
+    except (ValueError, OSError):
+        return True
+    return remote_dt <= local_dt
 
 
 def stream_to_disk(fetcher: Fetcher, asset: Asset, path: Path, etag: str | None) -> WriteResult:
@@ -271,9 +303,11 @@ __all__ = [
     "SkipRule",
     "WriteResult",
     "Writer",
+    "already_current",
     "atomic_write_bytes",
     "atomic_write_text",
     "csv_to_disk",
+    "exists",
     "fetch_all",
     "stream_to_disk",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,20 @@ from tests.fakes import InMemoryFetcher
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
+# A CH2025 climate-scenario CSV: the KEY;VALUE preamble, then the real DATE;
+# header on nominal 30-year dates. Shared because three test modules parse one —
+# the conventions, the convert stage, and the public load path.
+CLIMATE_SCENARIOS_CSV = (
+    "TITLE;Climate CH2025\n"
+    "VARIABLE;Daily precipitation sum\n"
+    "STATION_ABBR;ABE\n"
+    "GWL;GWL1.5\n"
+    "\n"
+    "DATE;MODEL_A;MODEL_B\n"
+    "0001-01-01;0;24.2\n"
+    "0001-01-02;1.5;0\n"
+)
+
 
 @pytest.fixture
 def fetcher(monkeypatch):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import polars as pl
 import pytest
+from conftest import CLIMATE_SCENARIOS_CSV
 
 import foehn
 from foehn.api import (
@@ -133,11 +134,6 @@ def test_load_indoor_station_filter(fetcher):
 
 # --- climate_scenarios (C8: metadata preamble + wide model table) ---
 
-_CS_CSV = (
-    "TITLE;X\nVARIABLE;Daily precipitation sum\nGWL;GWL1.5\n\n"
-    "DATE;MODEL_A;MODEL_B\n0001-01-01;0;24.2\n0001-01-02;1.5;0\n"
-)
-
 
 def test_load_climate_scenarios_year_filter_raises():
     with pytest.raises(ValueError, match="nominal"):
@@ -147,7 +143,7 @@ def test_load_climate_scenarios_year_filter_raises():
 def test_load_climate_scenarios_returns_dataframe(fetcher):
     href = "https://data.geo.admin.ch/x/ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv"
     fetcher.any_items = [{"id": "abe", "assets": {"d": {"href": href}}}]
-    fetcher.default_body = _CS_CSV
+    fetcher.default_body = CLIMATE_SCENARIOS_CSV
 
     df = load("climate_scenarios")
     assert isinstance(df, pl.DataFrame)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,121 +1,52 @@
-"""Tests for CSV/TXT → Parquet conversion."""
+"""Tests for the Bronze → Parquet convert stage.
+
+How a MeteoSwiss CSV is decoded, typed and grouped is tested in test_meteocsv;
+what is here is grouping into outputs, the up-to-date skip, the atomic write and
+the per-kind converters.
+"""
 
 import shutil
 from pathlib import Path
 
 import polars as pl
 import pytest
+from conftest import CLIMATE_SCENARIOS_CSV
 
 from foehn.convert import (
-    add_forecast_local_timestamp,
     convert_indoor_to_parquet,
     convert_normals_to_parquet,
     convert_preamble_to_parquet,
     convert_to_parquet,
-    decode_meteoswiss_csv,
-    group_csv_files,
-    load_metadata_types,
-    parse_climate_scenarios_csv,
-    parse_csv_bytes,
-    parse_metadata_types,
-    scan_climate_scenarios_csv,
 )
 from foehn.workspace import Workspace
-
-
-def test_decode_meteoswiss_csv_handles_utf8_and_windows1252():
-    assert decode_meteoswiss_csv("café".encode()) == "café"
-    assert decode_meteoswiss_csv("café".encode("utf-8-sig")) == "café"  # BOM stripped
-    assert decode_meteoswiss_csv(b"caf\xe9") == "café"  # Windows-1252 fallback
-
-
-def test_decode_meteoswiss_csv_is_total():
-    # 0x81 is invalid UTF-8 *and* unmapped in cp1252 — must replace, not raise.
-    decoded = decode_meteoswiss_csv(b"col\n\x81\n")
-    assert "col" in decoded
-
-
-def test_parse_climate_scenarios_csv_rejects_short_filename():
-    content = b"DATE;MODEL_A\n0001-01-01;1.0\n"
-    with pytest.raises(ValueError, match="Unexpected climate-scenario filename"):
-        parse_climate_scenarios_csv(content, "weird.csv")
-
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture()
 def smn_workspace(tmp_path):
-    """A smn_workspace whose bronze holds SMN CSVs and metadata."""
+    """A workspace whose bronze holds SMN CSVs and metadata."""
     smn_dir = Workspace(tmp_path).bronze("smn")
     smn_dir.mkdir(parents=True)
-    # Two station files in the same group (d_recent) to test combining.
     shutil.copy(FIXTURES_DIR / "smn_sample.csv", smn_dir / "ogd-smn_abo_d_recent.csv")
     shutil.copy(FIXTURES_DIR / "smn_sample.csv", smn_dir / "ogd-smn_ber_d_recent.csv")
-    shutil.copy(
-        FIXTURES_DIR / "smn_meta_parameters.csv",
-        smn_dir / "ogd-smn_meta_parameters.csv",
-    )
+    shutil.copy(FIXTURES_DIR / "smn_meta_parameters.csv", smn_dir / "ogd-smn_meta_parameters.csv")
     return Workspace(tmp_path)
 
 
 @pytest.fixture()
 def climate_normals_workspace(tmp_path):
-    """A climate_normals_workspace whose bronze holds a single climate normals TXT."""
+    """A workspace whose bronze holds a single climate normals TXT."""
     cn_dir = Workspace(tmp_path).bronze("climate_normals")
     cn_dir.mkdir(parents=True)
     shutil.copy(FIXTURES_DIR / "climate_normals_sample.txt", cn_dir / "sample.txt")
     return Workspace(tmp_path)
 
 
-# --- group_csv_files ---
-
-
-def test_group_csv_files(smn_workspace):
-    groups = group_csv_files(smn_workspace.bronze("smn"), "smn")
-    assert ("d", "recent") in groups
-    assert len(groups[("d", "recent")]) == 2
-
-
-def test_group_csv_files_excludes_meta(smn_workspace):
-    groups = group_csv_files(smn_workspace.bronze("smn"), "smn")
-    all_files = [f for files in groups.values() for f in files]
-    assert all("_meta_" not in f.name for f in all_files)
-
-
-def test_group_csv_files_empty(tmp_path):
-    empty_dir = tmp_path / "smn"
-    empty_dir.mkdir()
-    assert group_csv_files(empty_dir, "smn") == {}
-
-
-def test_group_csv_files_decade_split_historical_share_one_group(tmp_path):
-    """Per-decade historical chunks belong to the same (frequency, slice) group."""
-    d = tmp_path / "smn"
-    d.mkdir()
-    for name in ("ogd-smn_ber_t_historical_2000-2009.csv", "ogd-smn_ber_t_historical_2010-2019.csv"):
-        (d / name).write_text("a;b\n1;2\n")
-
-    groups = group_csv_files(d, "smn")
-    assert list(groups) == [("t", "historical")]
-    assert len(groups[("t", "historical")]) == 2
-
-
-def test_group_csv_files_no_granularity_collection_is_one_group(tmp_path):
-    """forecast_local filenames don't carry the collection prefix at all.
-
-    They are vnut12.lssw.<run>.<param>.csv, so the prefix-stripping path would
-    slice arbitrary characters off the stem — the collection collapses to a
-    single unkeyed group instead.
-    """
-    d = tmp_path / "forecast_local"
-    d.mkdir()
-    for name in ("vnut12.lssw.202607210600.dkl010h0.csv", "vnut12.lssw.202607210600.tre200h0.csv"):
-        (d / name).write_text("a;b\n1;2\n")
-
-    groups = group_csv_files(d, "forecast_local")
-    assert list(groups) == [()]
-    assert len(groups[()]) == 2
+_INDOOR_CSV = (
+    "time.yy,time.mm,time.dd,time.hh,tre200h0,ure200h0\n"
+    "2035,1,1,0,0.3,94.5\n2035,1,1,1,-0.2,94.6\n2035,1,1,2,-0.5,94.8\n"
+)
 
 
 # --- convert_to_parquet ---
@@ -202,24 +133,6 @@ def test_convert_to_parquet_no_csv_is_noop(tmp_path):
     assert not (parquet_dir / "smn").exists() or not list((parquet_dir / "smn").iterdir())
 
 
-# --- load_metadata_types ---
-
-
-def test_load_metadata_types(smn_workspace):
-    """Metadata file should produce a mapping of parameter names to Polars dtypes."""
-    types = load_metadata_types(smn_workspace.bronze("smn"))
-    assert types["tre200d0"] == pl.Float64
-    assert types["rre150d0"] == pl.Float64
-    assert types["ure200d0"] == pl.Int64
-    assert types["sre000d0"] == pl.Int64
-    assert "station_abbr" not in types
-
-
-def test_load_metadata_types_no_file(tmp_path):
-    """Returns empty dict when no metadata file exists."""
-    assert load_metadata_types(tmp_path) == {}
-
-
 def test_convert_applies_metadata_types(smn_workspace, tmp_path):
     """Columns listed as Float in metadata should be Float64 in the Parquet output."""
     parquet_dir = smn_workspace.parquet()
@@ -259,53 +172,6 @@ def test_convert_normals_readable(climate_normals_workspace, tmp_path):
     assert "Station" in df.columns
     assert "Jan" in df.columns
     assert len(df) == 2
-
-
-# --- parse_metadata_types edge cases ---
-
-
-def test_parse_metadata_types_invalid_content():
-    """Unparseable content returns empty dict."""
-    assert parse_metadata_types(b"not;valid;csv\x00\xff") == {}
-
-
-def test_parse_metadata_types_missing_columns():
-    """CSV without expected columns returns empty dict."""
-    assert parse_metadata_types(b"col_a;col_b\nfoo;bar\n") == {}
-
-
-# --- parse_csv_bytes edge cases ---
-
-
-def test_parse_csv_bytes_header_read_failure():
-    """When metadata_types are given but header reading fails, parsing still works."""
-    content = b"a;b\n1;2\n3;4\n"
-    # Pass metadata types but with a bad separator scenario — should still parse
-    df = parse_csv_bytes(content, metadata_types={"a": pl.Float64})
-    assert len(df) == 2
-
-
-def test_parse_csv_bytes_conversion_error_without_column_match():
-    """When error message doesn't contain a column name, the error is raised."""
-    # Create CSV that will cause an error Polars can't recover from
-    content = b""  # empty content
-    with pytest.raises(pl.exceptions.NoDataError):
-        parse_csv_bytes(content)
-
-
-def test_parse_csv_bytes_unwidenable_column_raises_instead_of_looping():
-    """Regression: a column that fails even as Float64 must raise, not retry forever.
-
-    The value sits past the 100-row inference window, so the column is inferred
-    Int64, the parse fails, the Float64 override is applied — and fails again.
-    Without the already-Float64 guard this re-parsed the same bytes infinitely.
-    """
-    rows = ["station_abbr;val"] + [f"BER;{i}" for i in range(150)]
-    rows[120] = "BER;abc"
-    content = "\n".join(rows).encode()
-
-    with pytest.raises(pl.exceptions.ComputeError):
-        parse_csv_bytes(content)
 
 
 # --- convert_to_parquet error handling ---
@@ -365,16 +231,6 @@ def test_convert_normals_handles_bad_file(tmp_path):
     assert failed >= 1
 
 
-# --- indoor climate scenarios (zipped multi-CSV) ---
-
-_INDOOR_CSV = (
-    "time.yy,time.mm,time.dd,time.hh,tre200h0,ure200h0,skycover\n"
-    "2035,1,1,0,0.3,94.5,36\n"
-    "2035,1,1,1,-0.2,94.6,26\n"
-    "2035,1,1,2,-0.5,94.3,20\n"
-)
-
-
 def test_convert_indoor_scenarios_parses_filename_and_timestamp(tmp_path):
     workspace = Workspace(tmp_path)
     bronze_dir = workspace.bronze()
@@ -425,37 +281,14 @@ def test_convert_indoor_scenarios_skips_metadata_file(tmp_path):
 
 # --- climate_scenarios C8 (metadata preamble + wide model table) ---
 
-_CS_CSV = (
-    "TITLE;Climate CH2025\n"
-    "VARIABLE;Daily precipitation sum\n"
-    "STATION_ABBR;ABE\n"
-    "GWL;GWL1.5\n"
-    "\n"
-    "DATE;MODEL_A;MODEL_B\n"
-    "0001-01-01;0;24.2\n"
-    "0001-01-02;1.5;0\n"
-)
-
-
-def test_parse_climate_scenarios_csv_skips_preamble():
-    df = parse_climate_scenarios_csv(_CS_CSV.encode("utf-8"), "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv")
-    assert df.columns[:4] == ["station_abbr", "variable", "gwl", "date"]
-    assert {"MODEL_A", "MODEL_B"} <= set(df.columns)
-    assert df["station_abbr"][0] == "abe"
-    assert df["variable"][0] == "pr"
-    assert df["gwl"][0] == "gwl1.5"
-    assert df["date"].to_list() == ["0001-01-01", "0001-01-02"]
-    assert df["MODEL_A"].dtype == pl.Float64
-    assert len(df) == 2
-
 
 def test_convert_preamble_to_parquet(tmp_path):
     workspace = Workspace(tmp_path)
     bronze_dir = workspace.bronze()
     cs_dir = bronze_dir / "climate_scenarios"
     cs_dir.mkdir(parents=True)
-    (cs_dir / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv").write_text(_CS_CSV)
-    (cs_dir / "ogd-climate-scenarios-ch2025_ber_tas_gwl2.0.csv").write_text(_CS_CSV)
+    (cs_dir / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv").write_text(CLIMATE_SCENARIOS_CSV)
+    (cs_dir / "ogd-climate-scenarios-ch2025_ber_tas_gwl2.0.csv").write_text(CLIMATE_SCENARIOS_CSV)
 
     parquet_dir = workspace.parquet()
     failed = convert_preamble_to_parquet("climate_scenarios", workspace)
@@ -468,31 +301,12 @@ def test_convert_preamble_to_parquet(tmp_path):
     assert len(df) == 4
 
 
-def test_scan_climate_scenarios_csv_is_lazy_and_matches_eager(tmp_path):
-    path = tmp_path / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv"
-    path.write_text(_CS_CSV)
-
-    lf = scan_climate_scenarios_csv(path)
-    assert isinstance(lf, pl.LazyFrame)
-    assert lf.collect().equals(parse_climate_scenarios_csv(_CS_CSV.encode("utf-8"), path.name))
-
-
-def test_scan_climate_scenarios_csv_survives_quote_in_preamble(tmp_path):
-    """A stray quote in a metadata value must not shift the header offset."""
-    path = tmp_path / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv"
-    path.write_text(_CS_CSV.replace("Daily precipitation sum", 'Daily precipitation ("mm")'))
-
-    df = scan_climate_scenarios_csv(path).collect()
-    assert df.columns[:4] == ["station_abbr", "variable", "gwl", "date"]
-    assert len(df) == 2
-
-
 def test_convert_preamble_to_parquet_counts_bad_file(tmp_path):
     workspace = Workspace(tmp_path)
     bronze_dir = workspace.bronze()
     cs_dir = bronze_dir / "climate_scenarios"
     cs_dir.mkdir(parents=True)
-    (cs_dir / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv").write_text(_CS_CSV)
+    (cs_dir / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv").write_text(CLIMATE_SCENARIOS_CSV)
     # No 'DATE;' header — must be skipped and counted, not abort the whole run.
     (cs_dir / "ogd-climate-scenarios-ch2025_ber_tas_gwl2.0.csv").write_text("TITLE;nope\n")
 
@@ -501,20 +315,3 @@ def test_convert_preamble_to_parquet_counts_bad_file(tmp_path):
 
     df = pl.read_parquet(parquet_dir / "climate_scenarios" / "climate_scenarios.parquet")
     assert set(df["station_abbr"].unique()) == {"abe"}
-
-
-# --- forecast_local Date -> reference_timestamp ---
-
-
-def test_add_forecast_local_timestamp():
-    df = pl.DataFrame({"point_id": [1], "Date": [202605202100], "dkl010h0": [282]})
-    out = add_forecast_local_timestamp(df)
-    assert "reference_timestamp" in out.columns
-    assert out["reference_timestamp"].dtype == pl.Datetime
-    ts = out["reference_timestamp"][0]
-    assert (ts.year, ts.month, ts.day, ts.hour) == (2026, 5, 20, 21)
-
-
-def test_add_forecast_local_timestamp_noop_without_date():
-    df = pl.DataFrame({"a": [1]})
-    assert add_forecast_local_timestamp(df).columns == ["a"]

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -1,0 +1,77 @@
+"""What each module in ``foehn`` is allowed to depend on.
+
+Asserted from the import graph rather than from a diagram, because the defect
+this guards against is invisible in any single file: ``transfer`` — the download
+engine — imported ``convert`` for one byte-level helper, so every module that
+used ``transfer`` depended on the Parquet conversion stage, including the
+gridded *read* path.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "foehn"
+
+
+def _imports(module: str) -> set[str]:
+    """Sibling modules *module* imports from ``foehn``."""
+    tree = ast.parse((SRC / f"{module}.py").read_text(encoding="utf-8"))
+    found = {
+        node.module.split(".")[1]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("foehn.")
+    }
+    return found - {module}
+
+
+def _graph() -> dict[str, set[str]]:
+    return {p.stem: _imports(p.stem) for p in SRC.glob("*.py") if p.stem != "__init__"}
+
+
+def test_the_import_graph_is_acyclic():
+    """A cycle is what forced the load path through an if-ladder in ``api`` once."""
+    graph = _graph()
+    visiting: set[str] = set()
+    done: set[str] = set()
+
+    def walk(node: str, trail: list[str]) -> None:
+        if node in done:
+            return
+        if node in visiting:
+            raise AssertionError(f"import cycle: {' -> '.join([*trail, node])}")
+        visiting.add(node)
+        for dep in sorted(graph.get(node, ())):
+            walk(dep, [*trail, node])
+        visiting.discard(node)
+        done.add(node)
+
+    for module in sorted(graph):
+        walk(module, [])
+
+
+def test_the_convert_stage_has_exactly_one_consumer():
+    """``convert`` is one pipeline stage, reached through the registry like the others.
+
+    Five modules used to import it; four wanted only the CSV conventions, which
+    are ``meteocsv`` now.
+    """
+    importers = {module for module, deps in _graph().items() if "convert" in deps}
+    assert importers == {"registry"}
+
+
+@pytest.mark.parametrize("module", ["transfer", "grids", "readers", "api", "client"])
+def test_nothing_but_the_registry_depends_on_parquet(module):
+    assert "convert" not in _imports(module)
+
+
+def test_meteocsv_is_the_bottom_of_the_read_stack():
+    """Upstream's file conventions know about datasets and nothing else."""
+    assert _imports("meteocsv") <= {"collections"}
+
+
+@pytest.mark.parametrize("module", ["collections", "workspace", "_urls"])
+def test_the_leaf_modules_import_no_foehn(module):
+    """Dataset facts, the layout and URL validation sit under everything."""
+    assert _imports(module) == set()

--- a/tests/test_meteocsv.py
+++ b/tests/test_meteocsv.py
@@ -1,0 +1,220 @@
+"""Tests for MeteoSwiss's CSV conventions — decoding, typing, filenames, preamble.
+
+Split out of test_convert alongside the module: these describe how upstream
+writes a file, and hold whether or not foehn ever produces a Parquet one.
+"""
+
+import shutil
+from pathlib import Path
+
+import polars as pl
+import pytest
+from conftest import CLIMATE_SCENARIOS_CSV
+
+from foehn.meteocsv import (
+    add_forecast_local_timestamp,
+    decode_meteoswiss_csv,
+    group_csv_files,
+    load_metadata_types,
+    parse_climate_scenarios_csv,
+    parse_csv_bytes,
+    parse_metadata_types,
+    scan_climate_scenarios_csv,
+)
+from foehn.workspace import Workspace
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture()
+def smn_workspace(tmp_path):
+    """A workspace whose bronze holds SMN CSVs and metadata."""
+    smn_dir = Workspace(tmp_path).bronze("smn")
+    smn_dir.mkdir(parents=True)
+    shutil.copy(FIXTURES_DIR / "smn_sample.csv", smn_dir / "ogd-smn_abo_d_recent.csv")
+    shutil.copy(FIXTURES_DIR / "smn_sample.csv", smn_dir / "ogd-smn_ber_d_recent.csv")
+    shutil.copy(FIXTURES_DIR / "smn_meta_parameters.csv", smn_dir / "ogd-smn_meta_parameters.csv")
+    return Workspace(tmp_path)
+
+
+def test_decode_meteoswiss_csv_handles_utf8_and_windows1252():
+    assert decode_meteoswiss_csv("café".encode()) == "café"
+    assert decode_meteoswiss_csv("café".encode("utf-8-sig")) == "café"  # BOM stripped
+    assert decode_meteoswiss_csv(b"caf\xe9") == "café"  # Windows-1252 fallback
+
+
+def test_decode_meteoswiss_csv_is_total():
+    # 0x81 is invalid UTF-8 *and* unmapped in cp1252 — must replace, not raise.
+    decoded = decode_meteoswiss_csv(b"col\n\x81\n")
+    assert "col" in decoded
+
+
+def test_parse_climate_scenarios_csv_rejects_short_filename():
+    content = b"DATE;MODEL_A\n0001-01-01;1.0\n"
+    with pytest.raises(ValueError, match="Unexpected climate-scenario filename"):
+        parse_climate_scenarios_csv(content, "weird.csv")
+
+
+# --- group_csv_files ---
+
+
+def test_group_csv_files(smn_workspace):
+    groups = group_csv_files(smn_workspace.bronze("smn"), "smn")
+    assert ("d", "recent") in groups
+    assert len(groups[("d", "recent")]) == 2
+
+
+def test_group_csv_files_excludes_meta(smn_workspace):
+    groups = group_csv_files(smn_workspace.bronze("smn"), "smn")
+    all_files = [f for files in groups.values() for f in files]
+    assert all("_meta_" not in f.name for f in all_files)
+
+
+def test_group_csv_files_empty(tmp_path):
+    empty_dir = tmp_path / "smn"
+    empty_dir.mkdir()
+    assert group_csv_files(empty_dir, "smn") == {}
+
+
+def test_group_csv_files_decade_split_historical_share_one_group(tmp_path):
+    """Per-decade historical chunks belong to the same (frequency, slice) group."""
+    d = tmp_path / "smn"
+    d.mkdir()
+    for name in ("ogd-smn_ber_t_historical_2000-2009.csv", "ogd-smn_ber_t_historical_2010-2019.csv"):
+        (d / name).write_text("a;b\n1;2\n")
+
+    groups = group_csv_files(d, "smn")
+    assert list(groups) == [("t", "historical")]
+    assert len(groups[("t", "historical")]) == 2
+
+
+def test_group_csv_files_no_granularity_collection_is_one_group(tmp_path):
+    """forecast_local filenames don't carry the collection prefix at all.
+
+    They are vnut12.lssw.<run>.<param>.csv, so the prefix-stripping path would
+    slice arbitrary characters off the stem — the collection collapses to a
+    single unkeyed group instead.
+    """
+    d = tmp_path / "forecast_local"
+    d.mkdir()
+    for name in ("vnut12.lssw.202607210600.dkl010h0.csv", "vnut12.lssw.202607210600.tre200h0.csv"):
+        (d / name).write_text("a;b\n1;2\n")
+
+    groups = group_csv_files(d, "forecast_local")
+    assert list(groups) == [()]
+    assert len(groups[()]) == 2
+
+
+# --- load_metadata_types ---
+
+
+def test_load_metadata_types(smn_workspace):
+    """Metadata file should produce a mapping of parameter names to Polars dtypes."""
+    types = load_metadata_types(smn_workspace.bronze("smn"))
+    assert types["tre200d0"] == pl.Float64
+    assert types["rre150d0"] == pl.Float64
+    assert types["ure200d0"] == pl.Int64
+    assert types["sre000d0"] == pl.Int64
+    assert "station_abbr" not in types
+
+
+def test_load_metadata_types_no_file(tmp_path):
+    """Returns empty dict when no metadata file exists."""
+    assert load_metadata_types(tmp_path) == {}
+
+
+# --- parse_metadata_types edge cases ---
+
+
+def test_parse_metadata_types_invalid_content():
+    """Unparseable content returns empty dict."""
+    assert parse_metadata_types(b"not;valid;csv\x00\xff") == {}
+
+
+def test_parse_metadata_types_missing_columns():
+    """CSV without expected columns returns empty dict."""
+    assert parse_metadata_types(b"col_a;col_b\nfoo;bar\n") == {}
+
+
+# --- parse_csv_bytes edge cases ---
+
+
+def test_parse_csv_bytes_header_read_failure():
+    """When metadata_types are given but header reading fails, parsing still works."""
+    content = b"a;b\n1;2\n3;4\n"
+    # Pass metadata types but with a bad separator scenario — should still parse
+    df = parse_csv_bytes(content, metadata_types={"a": pl.Float64})
+    assert len(df) == 2
+
+
+def test_parse_csv_bytes_conversion_error_without_column_match():
+    """When error message doesn't contain a column name, the error is raised."""
+    # Create CSV that will cause an error Polars can't recover from
+    content = b""  # empty content
+    with pytest.raises(pl.exceptions.NoDataError):
+        parse_csv_bytes(content)
+
+
+def test_parse_csv_bytes_unwidenable_column_raises_instead_of_looping():
+    """Regression: a column that fails even as Float64 must raise, not retry forever.
+
+    The value sits past the 100-row inference window, so the column is inferred
+    Int64, the parse fails, the Float64 override is applied — and fails again.
+    Without the already-Float64 guard this re-parsed the same bytes infinitely.
+    """
+    rows = ["station_abbr;val"] + [f"BER;{i}" for i in range(150)]
+    rows[120] = "BER;abc"
+    content = "\n".join(rows).encode()
+
+    with pytest.raises(pl.exceptions.ComputeError):
+        parse_csv_bytes(content)
+
+
+def test_parse_climate_scenarios_csv_skips_preamble():
+    df = parse_climate_scenarios_csv(
+        CLIMATE_SCENARIOS_CSV.encode("utf-8"), "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv"
+    )
+    assert df.columns[:4] == ["station_abbr", "variable", "gwl", "date"]
+    assert {"MODEL_A", "MODEL_B"} <= set(df.columns)
+    assert df["station_abbr"][0] == "abe"
+    assert df["variable"][0] == "pr"
+    assert df["gwl"][0] == "gwl1.5"
+    assert df["date"].to_list() == ["0001-01-01", "0001-01-02"]
+    assert df["MODEL_A"].dtype == pl.Float64
+    assert len(df) == 2
+
+
+def test_scan_climate_scenarios_csv_is_lazy_and_matches_eager(tmp_path):
+    path = tmp_path / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv"
+    path.write_text(CLIMATE_SCENARIOS_CSV)
+
+    lf = scan_climate_scenarios_csv(path)
+    assert isinstance(lf, pl.LazyFrame)
+    assert lf.collect().equals(parse_climate_scenarios_csv(CLIMATE_SCENARIOS_CSV.encode("utf-8"), path.name))
+
+
+def test_scan_climate_scenarios_csv_survives_quote_in_preamble(tmp_path):
+    """A stray quote in a metadata value must not shift the header offset."""
+    path = tmp_path / "ogd-climate-scenarios-ch2025_abe_pr_gwl1.5.csv"
+    path.write_text(CLIMATE_SCENARIOS_CSV.replace("Daily precipitation sum", 'Daily precipitation ("mm")'))
+
+    df = scan_climate_scenarios_csv(path).collect()
+    assert df.columns[:4] == ["station_abbr", "variable", "gwl", "date"]
+    assert len(df) == 2
+
+
+# --- forecast_local Date -> reference_timestamp ---
+
+
+def test_add_forecast_local_timestamp():
+    df = pl.DataFrame({"point_id": [1], "Date": [202605202100], "dkl010h0": [282]})
+    out = add_forecast_local_timestamp(df)
+    assert "reference_timestamp" in out.columns
+    assert out["reference_timestamp"].dtype == pl.Datetime
+    ts = out["reference_timestamp"][0]
+    assert (ts.year, ts.month, ts.day, ts.hour) == (2026, 5, 20, 21)
+
+
+def test_add_forecast_local_timestamp_noop_without_date():
+    df = pl.DataFrame({"a": [1]})
+    assert add_forecast_local_timestamp(df).columns == ["a"]


### PR DESCRIPTION
convert owned two things: how MeteoSwiss writes a CSV, and Bronze ->
Parquet. Five modules imported it and four wanted only the first — readers for the load path, transfer for one byte-level helper, api, and the Databricks script, which writes Delta and never produces a Parquet file. So the download engine depended on the Parquet converter, and the gridded read path did too, through transfer.

meteocsv holds the conventions: the encoding fallback, the dtype overrides, the KEY;VALUE preamble, the filename rules. convert keeps the stage and is now imported by registry alone. The polars dtype-error pattern was matched in both halves and is one function in meteocsv now.

test_layering asserts the graph rather than a diagram: acyclic, convert has one consumer, meteocsv sits under everything that reads a file.

Also: exists was defined identically in client and grids, and already_current only in client. Both are SkipRules, so both live in transfer next to the type that names them. The climate-scenario CSV fixture was copied in two test modules; it is in conftest now.