### PR TITLE
State the staging rule once, and let the public surface delegate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,6 +149,20 @@ filename rules that carry station, **Granularity**, **Time slice** and
 the load path, the convert stage and the Databricks ingest script alike.
 _Avoid_: parsing, format (a **Format** is a value; this is the rules for one)
 
+**Staging**:
+Writing to a sibling temp file and moving it onto the target, so a write that
+dies part-way leaves nothing rather than a truncated file with a fresh mtime —
+which every skip rule above it reads as "already done". One rule, under the
+**Fetcher**, **Transfer**, the convert stage and **Run state** alike.
+_Avoid_: atomic (it is not atomic on every filesystem; the move is what matters)
+
+**Metadata table**:
+One collection-level **Asset** — parameters, stations, inventory — and the
+columns foehn publishes from it. The suffix is MeteoSwiss's, the published names
+are foehn's. Not a **Dataset kind** thing: nothing about it varies by kind, so it
+is reached directly rather than through a registry row.
+_Avoid_: metadata (unqualified — the convert stage means dtypes by it)
+
 **Run state**:
 What foehn remembers between runs, in the **Workspace**: the ETag store keyed by
 asset href, and the last-run cursor the CLI advances only after a fully clean
@@ -265,3 +279,17 @@ _Avoid_: query, params, options
   paths), `odim` and `icon` carry upstream's conventions (what **MeteoSwiss
   CSV** is to the tabular path), and `grids` is the **Grid readers**. The same
   four-way split the tabular path already had.
+- **Staging** was stated four times — the **Fetcher**'s stream, **Transfer**'s
+  byte writer, the convert stage's Parquet writer and **Run state** — with three
+  suffixes and three docstrings reasoning their way to the same rule. **Run
+  state** reached into **Transfer**, the download engine, for a filesystem
+  primitive that was never the download path's to own. Resolved: `atomicwrite` is
+  a leaf and `test_layering` fails a module that hand-rolls the move itself.
+- `api` — the public surface — held one stage outright rather than delegating:
+  the **Metadata tables** were fetched, decoded and renamed inline, so it was the
+  one entry point taking no **Fetcher** and reachable only through the
+  process-wide default. `to_zarr` likewise chose cube-vs-single itself. Resolved:
+  `metadata` owns the tables and their implementation, `registry.write_zarr`
+  owns the choice, and `api` states the contract and delegates. It imported nine
+  modules against `mcp_server`'s two; it imports seven now, and holds 51
+  statements where it held 80.

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -3,18 +3,16 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import polars as pl
 
 from foehn import registry
-from foehn.assets import collection_assets
-from foehn.collections import COLLECTION_META, COLLECTIONS, collection_id
+from foehn.collections import COLLECTION_META, COLLECTIONS
 from foehn.fetch import DEFAULT_WORKERS, default_fetcher
-from foehn.grids import sanitize_noncf_time_units, write_zarr
-from foehn.meteocsv import decode_meteoswiss_csv
+from foehn.metadata import TABLES as metadata_tables
+from foehn.metadata import fetch_table
 from foehn.readers import Filters
 from foehn.transfer import DownloadResult
 from foehn.workspace import Workspace
@@ -119,61 +117,9 @@ def to_parquet(
         )
 
 
-@dataclass(frozen=True)
-class MetadataTable:
-    """One collection-level metadata file, and the columns foehn publishes from it.
-
-    The suffix is MeteoSwiss's; the renames are foehn's public column names, which
-    is why the table lives here rather than in :mod:`foehn.meteocsv`. Stating it
-    once means a fourth ``_meta_*`` file is a row — it used to be three implied
-    rename maps here, an if-ladder in the CLI, and three models in the MCP layer.
-    """
-
-    suffix: str
-    """Filename fragment identifying the file among a collection's assets."""
-
-    columns: dict[str, str]
-    """Source column → published name, in the order the frame comes back."""
-
-
-METADATA_TABLES: dict[str, MetadataTable] = {
-    "parameters": MetadataTable(
-        "_meta_parameters",
-        {
-            "parameter_shortname": "shortname",
-            "parameter_description_en": "description",
-            "parameter_unit": "unit",
-            "parameter_datatype": "type",
-            "parameter_granularity": "granularity",
-            "parameter_decimals": "decimals",
-            "parameter_group_en": "group",
-        },
-    ),
-    "stations": MetadataTable(
-        "_meta_stations",
-        {
-            "station_abbr": "abbr",
-            "station_name": "name",
-            "station_canton": "canton",
-            "station_height_masl": "altitude",
-            "station_coordinates_lv95_east": "lv95_east",
-            "station_coordinates_lv95_north": "lv95_north",
-            "station_coordinates_wgs84_lat": "lat",
-            "station_coordinates_wgs84_lon": "lon",
-            "station_data_since": "data_since",
-        },
-    ),
-    "inventory": MetadataTable(
-        "_meta_datainventory",
-        {
-            "station_abbr": "station",
-            "parameter_shortname": "parameter",
-            "data_since": "data_since",
-            "data_till": "data_till",
-            "owner": "owner",
-        },
-    ),
-}
+# Re-exported: the tables and their published column names are ``foehn.metadata``'s,
+# but ``METADATA_TABLES`` is a public name and the CLI builds its ``choices`` from it.
+METADATA_TABLES = metadata_tables
 
 
 def metadata(dataset: str, table: str) -> pl.DataFrame:
@@ -190,18 +136,7 @@ def metadata(dataset: str, table: str) -> pl.DataFrame:
     Returns:
         A Polars DataFrame with foehn's published column names.
     """
-    if table not in METADATA_TABLES:
-        raise ValueError(f"Unknown metadata table {table!r}. Valid options: {', '.join(METADATA_TABLES)}.")
-
-    spec = METADATA_TABLES[table]
-    fetcher = default_fetcher()
-    coll = fetcher.collection(collection_id(dataset))
-    for asset in collection_assets(coll, suffixes=(".csv",), contains=spec.suffix):
-        content = decode_meteoswiss_csv(fetcher.get(asset.href, timeout=60).body)
-        df = pl.read_csv(content.encode("utf-8"), separator=";")
-        return df.select(pl.col(source).alias(published) for source, published in spec.columns.items())
-
-    raise ValueError(f"No {spec.suffix} metadata found for dataset {dataset!r}.")
+    return fetch_table(dataset, table, fetcher=default_fetcher())
 
 
 def parameters(dataset: str) -> pl.DataFrame:
@@ -482,41 +417,22 @@ def to_zarr(
     Returns:
         Path to the written ``.zarr`` store.
     """
-    # Also the unknown-dataset guard: the row is what says whether this kind has
-    # a cube builder, and asking for it raises for a dataset that has no row.
-    grid = registry.spec(dataset).grid
-    if stack and rechunk:
-        raise ValueError("rechunk= is not supported with stack= (the cube is written separately).")
-
     workspace = Workspace.resolve(data_dir)
     store_path = _resolve_store(dataset, match, workspace, store)
     store_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # NetCDF has no cube builder and needs none, so it falls through to the
-    # single-write path below.
-    if stack and grid is not None and grid.cube is not None:
-        registry.write_cube(
-            dataset,
-            store_path,
-            match=match,
-            variables=variables,
-            mode=mode,
-            workspace=workspace,
-            fetcher=default_fetcher(),
-        )
-        return store_path
-
-    ds = sanitize_noncf_time_units(open_dataset(dataset, variables=variables, match=match, data_dir=workspace.root))
-
-    if rechunk:
-        import importlib.util
-
-        if importlib.util.find_spec("dask") is None:
-            raise ImportError(
-                "to_zarr(rechunk=...) requires dask, which is not part of the "
-                "'grids' extra. Install it with:\n\n  pip install dask\n"
-            )
-        ds = ds.chunk(rechunk)
-
-    write_zarr(ds, store_path, mode)
+    # Which method writes it — cube or single — is the kind's row, not a branch
+    # here. So is whether the dataset has a Zarr path at all, which is what makes
+    # this the unknown-dataset guard too.
+    registry.write_zarr(
+        dataset,
+        store_path,
+        match=match,
+        variables=variables,
+        rechunk=rechunk,
+        mode=mode,
+        stack=stack,
+        workspace=workspace,
+        fetcher=default_fetcher(),
+    )
     return store_path

--- a/src/foehn/atomicwrite.py
+++ b/src/foehn/atomicwrite.py
@@ -1,0 +1,54 @@
+"""Never leave a torn file at its final path.
+
+Every write foehn makes to the **Workspace** stages into a sibling temp file and
+``Path.replace``s it into place, so a write that dies part-way leaves nothing
+rather than a truncated file with a fresh mtime — which the skip rules above it
+read as "already done" and never retry.
+
+One rule, stated once. It used to be written out four times: the download
+engine's byte writer, the streaming fetcher, the Parquet converter, and the run
+state, which reached into the download engine for it. Three suffixes and three
+docstrings, all reasoning their way to the same thing.
+
+A leaf: this knows about the filesystem and nothing about foehn.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from pathlib import Path
+
+
+@contextlib.contextmanager
+def staged(path: Path, *, suffix: str = ".tmp") -> Iterator[Path]:
+    """Yield a sibling path to write to, then move it onto *path*.
+
+    The move happens when the block completes; the temp file is removed when it
+    raises. ``BaseException``, not ``Exception``: a KeyboardInterrupt mid-write
+    leaves a partial file exactly as a disk-full error does.
+
+    The suffix is visible in the directory while the write is in flight, so it
+    is worth naming for what it is — the fetcher stages ``.part``.
+    """
+    tmp = path.with_name(path.name + suffix)
+    try:
+        yield tmp
+        tmp.replace(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def write_bytes(path: Path, data: bytes | memoryview) -> None:
+    """Write bytes to *path* so readers never see a torn write."""
+    with staged(path) as tmp:
+        tmp.write_bytes(data)
+
+
+def write_text(path: Path, text: str) -> None:
+    """Write UTF-8 text to *path* so readers never see a torn write."""
+    write_bytes(path, text.encode("utf-8"))
+
+
+__all__ = ["staged", "write_bytes", "write_text"]

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -16,6 +16,7 @@ from typing import Literal
 
 import polars as pl
 
+from foehn.atomicwrite import staged
 from foehn.meteocsv import (
     add_indoor_columns,
     column_from_dtype_error,
@@ -47,16 +48,11 @@ def _write_parquet_atomic(
     skip from then on, so the next run reports success over a corrupt file.
     Staging into a temp file means a failed write leaves nothing at all.
     """
-    tmp = path.with_name(path.name + ".tmp")
-    try:
+    with staged(path) as tmp:
         if isinstance(frame, pl.LazyFrame):
             frame.sink_parquet(tmp, compression=compression)
         else:
             frame.write_parquet(tmp, compression=compression)
-        tmp.replace(path)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
 
 
 @dataclass(frozen=True)

--- a/src/foehn/fetch.py
+++ b/src/foehn/fetch.py
@@ -26,6 +26,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from foehn._urls import validate_download_href, validate_stac_url
+from foehn.atomicwrite import staged
 from foehn.collections import STAC_API_BASE
 
 logger = logging.getLogger(__name__)
@@ -185,17 +186,15 @@ class HttpFetcher:
         for a complete one.
         """
         validate_download_href(url)
-        tmp = path.with_name(path.name + ".part")
-        try:
-            with _as_fetch_error(url), self._session().get(url, stream=True, timeout=timeout) as resp:
-                resp.raise_for_status()
-                with tmp.open("wb") as fh:
-                    for chunk in resp.iter_content(chunk_size=65536):
-                        fh.write(chunk)
-            tmp.replace(path)
-        except BaseException:
-            tmp.unlink(missing_ok=True)
-            raise
+        with (
+            staged(path, suffix=".part") as tmp,
+            _as_fetch_error(url),
+            self._session().get(url, stream=True, timeout=timeout) as resp,
+        ):
+            resp.raise_for_status()
+            with tmp.open("wb") as fh:
+                for chunk in resp.iter_content(chunk_size=65536):
+                    fh.write(chunk)
 
     def items(
         self,

--- a/src/foehn/grids.py
+++ b/src/foehn/grids.py
@@ -99,6 +99,22 @@ def require_grib2() -> None:
         ) from exc
 
 
+def require_dask() -> None:
+    """A :data:`Require` for ``rechunk=``: dask is *not* part of the 'grids' extra.
+
+    Named here with the other three so every optional-import message foehn can
+    raise sits in one place, even though nothing in ``KINDS`` carries this one —
+    rechunking is a caller's request, not a property of a kind.
+    """
+    import importlib.util
+
+    if importlib.util.find_spec("dask") is None:
+        raise ImportError(
+            "to_zarr(rechunk=...) requires dask, which is not part of the "
+            "'grids' extra. Install it with:\n\n  pip install dask\n"
+        )
+
+
 def require_radar() -> None:
     """A :data:`Require`: ODIM composites need xarray plus h5py + pyproj."""
     _require_xarray()
@@ -469,6 +485,7 @@ __all__ = [
     "open_grib2",
     "open_netcdf",
     "open_radar",
+    "require_dask",
     "require_grib2",
     "require_netcdf",
     "require_radar",

--- a/src/foehn/metadata.py
+++ b/src/foehn/metadata.py
@@ -1,0 +1,106 @@
+"""A **Collection**'s metadata tables, and the columns foehn publishes from them.
+
+The parameters, stations and inventory tables are collection-level **Assets**:
+one shared set per **Collection**, fetched live rather than read from **Bronze**.
+This is where they are turned into a frame.
+
+Not routed through :mod:`foehn.registry` like the four kind-shaped stages, and
+deliberately so: nothing about this varies by **Dataset kind**, so a row and an
+adapter per kind would be a seam with nothing on either side of it. What it does
+share with those stages is its shape — the **Fetcher** is passed in, so this is
+reachable in a test without substituting the process-wide default.
+
+The suffixes are MeteoSwiss's; the published names are foehn's. Stating the pair
+once means a fourth ``_meta_*`` file is a row: it used to be three implied rename
+maps in ``api``, an if-ladder in the CLI, and three models in the MCP layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import polars as pl
+
+from foehn.assets import collection_assets
+from foehn.collections import collection_id
+from foehn.fetch import Fetcher
+from foehn.meteocsv import decode_meteoswiss_csv
+
+
+@dataclass(frozen=True)
+class MetadataTable:
+    """One collection-level metadata file, and the columns foehn publishes from it.
+
+    The suffix is MeteoSwiss's; the renames are foehn's public column names, which
+    is why the table lives here rather than in :mod:`foehn.meteocsv`. Stating it
+    once means a fourth ``_meta_*`` file is a row — it used to be three implied
+    rename maps here, an if-ladder in the CLI, and three models in the MCP layer.
+    """
+
+    suffix: str
+    """Filename fragment identifying the file among a collection's assets."""
+
+    columns: dict[str, str]
+    """Source column → published name, in the order the frame comes back."""
+
+
+TABLES: dict[str, MetadataTable] = {
+    "parameters": MetadataTable(
+        "_meta_parameters",
+        {
+            "parameter_shortname": "shortname",
+            "parameter_description_en": "description",
+            "parameter_unit": "unit",
+            "parameter_datatype": "type",
+            "parameter_granularity": "granularity",
+            "parameter_decimals": "decimals",
+            "parameter_group_en": "group",
+        },
+    ),
+    "stations": MetadataTable(
+        "_meta_stations",
+        {
+            "station_abbr": "abbr",
+            "station_name": "name",
+            "station_canton": "canton",
+            "station_height_masl": "altitude",
+            "station_coordinates_lv95_east": "lv95_east",
+            "station_coordinates_lv95_north": "lv95_north",
+            "station_coordinates_wgs84_lat": "lat",
+            "station_coordinates_wgs84_lon": "lon",
+            "station_data_since": "data_since",
+        },
+    ),
+    "inventory": MetadataTable(
+        "_meta_datainventory",
+        {
+            "station_abbr": "station",
+            "parameter_shortname": "parameter",
+            "data_since": "data_since",
+            "data_till": "data_till",
+            "owner": "owner",
+        },
+    ),
+}
+
+
+def fetch_table(dataset: str, table: str, *, fetcher: Fetcher) -> pl.DataFrame:
+    """Fetch one of a dataset's metadata tables from the STAC API.
+
+    The single implementation behind ``foehn.parameters``, ``foehn.stations`` and
+    ``foehn.inventory``, which differ only in which row they ask for.
+    """
+    if table not in TABLES:
+        raise ValueError(f"Unknown metadata table {table!r}. Valid options: {', '.join(TABLES)}.")
+
+    spec = TABLES[table]
+    coll = fetcher.collection(collection_id(dataset))
+    for asset in collection_assets(coll, suffixes=(".csv",), contains=spec.suffix):
+        content = decode_meteoswiss_csv(fetcher.get(asset.href, timeout=60).body)
+        df = pl.read_csv(content.encode("utf-8"), separator=";")
+        return df.select(pl.col(source).alias(published) for source, published in spec.columns.items())
+
+    raise ValueError(f"No {spec.suffix} metadata found for dataset {dataset!r}.")
+
+
+__all__ = ["TABLES", "MetadataTable", "fetch_table"]

--- a/src/foehn/registry.py
+++ b/src/foehn/registry.py
@@ -42,6 +42,7 @@ from foehn.downloads import (
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
 from foehn.gridfiles import ensure_grid_files
 from foehn.grids import (
+    CubeAdapter,
     GridReader,
     cube_grib2,
     cube_radar,
@@ -442,6 +443,7 @@ def _write_cube(
     dataset: str,
     store: Path,
     reader: GridReader,
+    cube: CubeAdapter,
     *,
     match: str | None = None,
     variables: str | list[str] | None = None,
@@ -451,8 +453,10 @@ def _write_cube(
 ) -> None:
     """Assemble *dataset*'s matched files into one Zarr store at *store*.
 
-    Takes the reader rather than looking it up: :func:`write_zarr` has already
-    resolved it, and has already established that this kind has a cube builder.
+    Takes the reader *and* the cube adapter :func:`write_zarr` picked off it.
+    A kind with no cube builder cannot reach here, and saying that in the
+    signature is what makes it true — the runtime guard this replaces could only
+    check it after the fact.
     """
     if match is None:
         raise ValueError(
@@ -468,7 +472,7 @@ def _write_cube(
         run_datetime=reader.run_datetime,
         fetcher=fetcher,
     )
-    reader.cube(
+    cube(
         files,
         store,
         dataset=dataset,
@@ -502,9 +506,18 @@ def write_zarr(
     if stack and rechunk:
         raise ValueError("rechunk= is not supported with stack= (the cube is written separately).")
 
-    if stack and reader.cube is not None:
+    cube = reader.cube
+    if stack and cube is not None:
         _write_cube(
-            dataset, store, reader, match=match, variables=variables, mode=mode, workspace=workspace, fetcher=fetcher
+            dataset,
+            store,
+            reader,
+            cube,
+            match=match,
+            variables=variables,
+            mode=mode,
+            workspace=workspace,
+            fetcher=fetcher,
         )
         return
 

--- a/src/foehn/registry.py
+++ b/src/foehn/registry.py
@@ -48,11 +48,14 @@ from foehn.grids import (
     open_grib2,
     open_netcdf,
     open_radar,
+    require_dask,
     require_grib2,
     require_netcdf,
     require_radar,
+    sanitize_noncf_time_units,
     select_variables,
 )
+from foehn.grids import write_zarr as grids_write_zarr
 from foehn.transfer import DownloadResult, already_current, csv_to_disk, exists
 
 if TYPE_CHECKING:
@@ -435,9 +438,10 @@ def open_grid(
     return select_variables(reader.open(files, dataset=dataset, workspace=workspace, fetcher=fetcher), variables)
 
 
-def write_cube(
+def _write_cube(
     dataset: str,
     store: Path,
+    reader: GridReader,
     *,
     match: str | None = None,
     variables: str | list[str] | None = None,
@@ -447,13 +451,9 @@ def write_cube(
 ) -> None:
     """Assemble *dataset*'s matched files into one Zarr store at *store*.
 
-    Callers guard on ``spec(dataset).grid.cube`` first — a kind with no cube
-    builder needs none, which is a fact about the kind rather than a branch.
+    Takes the reader rather than looking it up: :func:`write_zarr` has already
+    resolved it, and has already established that this kind has a cube builder.
     """
-    reader = _grid_reader(dataset)
-    if reader.cube is None:
-        fmt = COLLECTION_META[dataset]["format"]
-        raise ValueError(f"Dataset {dataset!r} is {fmt}; a multi-file match= already combines on read.")
     if match is None:
         raise ValueError(
             f'stack= needs match= to scope the cube for {dataset!r}, e.g. match="{reader.cube_match_example}".'
@@ -477,6 +477,44 @@ def write_cube(
         variables=variables,
         mode=mode,
     )
+
+
+def write_zarr(
+    dataset: str,
+    store: Path,
+    *,
+    match: str | None = None,
+    variables: str | list[str] | None = None,
+    rechunk: dict[str, int] | None = None,
+    mode: str = "w",
+    stack: bool = False,
+    workspace: Workspace,
+    fetcher: Fetcher,
+) -> None:
+    """Write *dataset* to a Zarr store at *store*, by whichever method its kind uses.
+
+    ``stack`` asks for a cube; whether the kind *has* a cube builder is the row's
+    to say. NetCDF has none and needs none — a multi-file ``match`` combines on
+    read — so it falls through to the single write rather than raising, and
+    ``api.to_zarr`` no longer has to know that.
+    """
+    reader = _grid_reader(dataset)
+    if stack and rechunk:
+        raise ValueError("rechunk= is not supported with stack= (the cube is written separately).")
+
+    if stack and reader.cube is not None:
+        _write_cube(
+            dataset, store, reader, match=match, variables=variables, mode=mode, workspace=workspace, fetcher=fetcher
+        )
+        return
+
+    ds = sanitize_noncf_time_units(
+        open_grid(dataset, match=match, variables=variables, workspace=workspace, fetcher=fetcher)
+    )
+    if rechunk:
+        require_dask()
+        ds = ds.chunk(rechunk)
+    grids_write_zarr(ds, store, mode)
 
 
 def convert(dataset: str, workspace: Workspace) -> int:

--- a/src/foehn/state.py
+++ b/src/foehn/state.py
@@ -15,7 +15,7 @@ import json
 import logging
 from datetime import UTC, datetime
 
-from foehn.transfer import atomic_write_text
+from foehn.atomicwrite import write_text
 from foehn.workspace import Workspace
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ def load_etags(workspace: Workspace) -> dict:
 def save_etags(workspace: Workspace, etags: dict):
     path = workspace.etags
     path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_text(path, json.dumps(etags, indent=2))
+    write_text(path, json.dumps(etags, indent=2))
 
 
 def load_last_run(workspace: Workspace) -> str | None:
@@ -53,4 +53,4 @@ def load_last_run(workspace: Workspace) -> str | None:
 def save_last_run(workspace: Workspace):
     path = workspace.last_run
     path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_text(path, json.dumps({"timestamp": datetime.now(UTC).isoformat()}))
+    write_text(path, json.dumps({"timestamp": datetime.now(UTC).isoformat()}))

--- a/src/foehn/transfer.py
+++ b/src/foehn/transfer.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
+from foehn import atomicwrite
 from foehn.assets import Asset
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
 from foehn.meteocsv import utf8_meteoswiss_csv
@@ -69,25 +70,6 @@ class DownloadResult:
             failed=self.failed + other.failed,
             filenames=self.filenames + other.filenames,
         )
-
-
-# --- Atomic writes ---
-
-
-def atomic_write_bytes(path: Path, data: bytes | memoryview) -> None:
-    """Write bytes via a sibling temp file + Path.replace so readers never see a torn write."""
-    tmp = path.with_name(path.name + ".tmp")
-    try:
-        tmp.write_bytes(data)
-        tmp.replace(path)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
-
-
-def atomic_write_text(path: Path, text: str) -> None:
-    """Write text via a sibling temp file + Path.replace so readers never see a torn write."""
-    atomic_write_bytes(path, text.encode("utf-8"))
 
 
 # --- Writers: how one asset becomes one file ---
@@ -164,7 +146,7 @@ def csv_to_disk(fetcher: Fetcher, asset: Asset, path: Path, etag: str | None) ->
     fetched = fetcher.get(asset.href, etag=validator, timeout=60)
     if fetched.not_modified:
         return WriteResult(downloaded=False)
-    atomic_write_bytes(path, utf8_meteoswiss_csv(fetched.body))
+    atomicwrite.write_bytes(path, utf8_meteoswiss_csv(fetched.body))
     return WriteResult(downloaded=True, etag=fetched.etag)
 
 
@@ -304,8 +286,6 @@ __all__ = [
     "WriteResult",
     "Writer",
     "already_current",
-    "atomic_write_bytes",
-    "atomic_write_text",
     "csv_to_disk",
     "exists",
     "fetch_all",

--- a/tests/test_atomicwrite.py
+++ b/tests/test_atomicwrite.py
@@ -1,0 +1,75 @@
+"""Tests for the staging rule every write to the Workspace goes through.
+
+A leaf module, so these need no fetcher, no workspace and no dataset. What they
+assert is the property the four callers were each reasoning their way to: after
+a failed write there is nothing at the target and nothing beside it.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from foehn.atomicwrite import staged, write_bytes, write_text
+
+
+def test_bytes_land_at_the_target(tmp_path):
+    target = tmp_path / "asset.csv"
+    write_bytes(target, b"payload")
+
+    assert target.read_bytes() == b"payload"
+    assert list(tmp_path.iterdir()) == [target]  # nothing staged left over
+
+
+def test_text_is_written_as_utf8(tmp_path):
+    target = tmp_path / "state.json"
+    write_text(target, '{"station": "Zürich"}')
+
+    assert target.read_bytes() == '{"station": "Zürich"}'.encode()
+
+
+def test_a_failed_write_leaves_neither_the_target_nor_the_staged_file(tmp_path):
+    """The whole point: a truncated file with a fresh mtime reads as "already done"."""
+    target = tmp_path / "asset.csv"
+
+    with patch.object(Path, "replace", side_effect=OSError("disk full")), pytest.raises(OSError):
+        write_bytes(target, b"payload")
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_failed_write_does_not_disturb_the_file_already_there(tmp_path):
+    """The replace is the commit point, so the previous version survives a failure."""
+    target = tmp_path / "asset.csv"
+    target.write_bytes(b"the good copy")
+
+    with patch.object(Path, "replace", side_effect=OSError("disk full")), pytest.raises(OSError):
+        write_bytes(target, b"the truncated one")
+
+    assert target.read_bytes() == b"the good copy"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["asset.csv"]
+
+
+def test_an_interrupt_mid_write_is_cleaned_up_like_any_other_failure(tmp_path):
+    """BaseException, not Exception — Ctrl-C leaves a partial file exactly as disk-full does."""
+    target = tmp_path / "asset.csv"
+
+    with pytest.raises(KeyboardInterrupt), staged(target) as tmp:
+        tmp.write_bytes(b"half a fi")
+        raise KeyboardInterrupt
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_the_staged_file_sits_beside_the_target_under_the_given_suffix(tmp_path):
+    """The suffix is visible in the directory while the write is in flight."""
+    target = tmp_path / "grid.grib2"
+    seen = []
+
+    with staged(target, suffix=".part") as tmp:
+        tmp.write_bytes(b"x")
+        seen = sorted(p.name for p in tmp_path.iterdir())
+
+    assert seen == ["grid.grib2.part"]
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["grid.grib2"]

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -91,9 +91,9 @@ def test_meteocsv_is_the_bottom_of_the_read_stack():
     assert _imports("meteocsv") <= {"collections"}
 
 
-@pytest.mark.parametrize("module", ["collections", "workspace", "_urls", "archives", "odim"])
+@pytest.mark.parametrize("module", ["collections", "workspace", "_urls", "archives", "odim", "atomicwrite"])
 def test_the_leaf_modules_import_no_foehn(module):
-    """Dataset facts, the layout, URL validation, the ZIP guards and ODIM sit under everything.
+    """Dataset facts, the layout, URL validation, the ZIP guards, ODIM and staging sit under everything.
 
     ``odim`` is upstream's radar file format and nothing else: one path in, one
     Dataset out. It takes ``xr`` as an argument rather than importing it, so it
@@ -112,6 +112,29 @@ def test_the_grid_readers_do_not_know_how_files_arrive():
     assert "transfer" not in deps
     assert "assets" not in deps
     assert "gridfiles" not in deps
+
+
+def test_the_run_state_does_not_depend_on_the_download_engine():
+    """``state`` imported ``transfer`` for one filesystem primitive, which is ``atomicwrite`` now.
+
+    The same shape as ``transfer`` importing ``convert``: a module reaching into
+    a pipeline stage for a helper that was never that stage's to own.
+    """
+    assert _imports("state") == {"atomicwrite", "workspace"}
+
+
+def test_every_write_to_the_workspace_stages():
+    """Four modules used to state the temp-file-then-replace rule; now they call it.
+
+    Guards the rule itself rather than the imports: a fifth writer that hand-rolls
+    ``.replace`` is exactly the regression this split was for.
+    """
+    hand_rolled = {
+        module
+        for module in ("transfer", "convert", "fetch", "state", "downloads", "gridfiles")
+        if ".replace(path)" in (SRC / f"{module}.py").read_text(encoding="utf-8")
+    }
+    assert hand_rolled == set()
 
 
 def test_the_grid_fetching_has_one_consumer():

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -137,6 +137,24 @@ def test_every_write_to_the_workspace_stages():
     assert hand_rolled == set()
 
 
+def test_the_public_surface_only_delegates():
+    """``api`` states the public contract; every stage below it is reached through a seam.
+
+    It used to hold one stage outright — the metadata tables, fetched, decoded and
+    renamed inline — and to pick cube-vs-single itself in ``to_zarr``, which is
+    why it reached into ``assets``, ``meteocsv`` and ``grids`` while ``mcp_server``,
+    a peer front end, needed only the registry.
+    """
+    forbidden = {"assets", "meteocsv", "grids", "gridfiles", "downloads", "convert", "icon", "odim"}
+    assert _imports("api") & forbidden == set()
+
+
+def test_the_metadata_tables_have_one_consumer():
+    """Reached through ``api``'s three wrappers, like every other stage through its seam."""
+    importers = {module for module, deps in _graph().items() if "metadata" in deps}
+    assert importers == {"api"}
+
+
 def test_the_grid_fetching_has_one_consumer():
     """Like ``convert`` and ``downloads``: reached through the registry, not called directly."""
     importers = {module for module, deps in _graph().items() if "gridfiles" in deps}

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,99 @@
+"""Tests at :mod:`foehn.metadata`'s interface.
+
+The three public wrappers are covered through ``foehn.parameters`` and friends in
+``test_api``, which is where callers meet them. These go at the module itself,
+passing the fetcher in — which is what moving it out of ``api`` bought, and why
+none of them touches the process-wide default.
+"""
+
+from __future__ import annotations
+
+import re
+
+import polars as pl
+import pytest
+
+from foehn.metadata import TABLES, fetch_table
+from tests.fakes import InMemoryFetcher, stac_collection
+
+_PARAMETERS_CSV = (
+    "parameter_shortname;parameter_description_en;parameter_unit;parameter_datatype;"
+    "parameter_granularity;parameter_decimals;parameter_group_en\n"
+    "tre200d0;Air temperature 2 m;°C;Float;d;1;Temperature\n"
+)
+
+
+def _fake(*hrefs, body=_PARAMETERS_CSV):
+    fake = InMemoryFetcher()
+    fake.any_collection = stac_collection("ch.meteoschweiz.ogd-smn", *hrefs)
+    fake.default_body = body
+    return fake
+
+
+def test_a_table_is_published_under_foehns_column_names():
+    """The suffix is MeteoSwiss's, the names are foehn's — that pair is the whole table."""
+    fake = _fake("https://data.geo.admin.ch/x/ogd-smn_meta_parameters.csv")
+
+    df = fetch_table("smn", "parameters", fetcher=fake)
+
+    assert df.columns == list(TABLES["parameters"].columns.values())
+    assert df["shortname"].to_list() == ["tre200d0"]
+    assert df["unit"].to_list() == ["°C"]
+
+
+def test_the_columns_come_back_in_the_declared_order():
+    """Order is part of the table, not an accident of the source file's column order."""
+    fake = _fake("https://data.geo.admin.ch/x/ogd-smn_meta_parameters.csv")
+
+    df = fetch_table("smn", "parameters", fetcher=fake)
+
+    assert df.columns == ["shortname", "description", "unit", "type", "granularity", "decimals", "group"]
+
+
+def test_a_table_that_does_not_exist_names_the_ones_that_do():
+    with pytest.raises(ValueError, match="Unknown metadata table 'stations_v2'"):
+        fetch_table("smn", "stations_v2", fetcher=_fake())
+
+    with pytest.raises(ValueError, match="parameters, stations, inventory"):
+        fetch_table("smn", "stations_v2", fetcher=_fake())
+
+
+def test_a_collection_missing_the_asset_names_the_suffix_it_looked_for():
+    """The collection is there and the file is not — which is upstream's problem, said plainly."""
+    fake = _fake("https://data.geo.admin.ch/x/ogd-smn_meta_stations.csv")
+
+    with pytest.raises(ValueError, match=re.escape("No _meta_parameters metadata found for dataset 'smn'")):
+        fetch_table("smn", "parameters", fetcher=fake)
+
+
+def test_an_unknown_dataset_is_refused_before_any_fetch():
+    """``collection_id`` raises the sentence; nothing here restates it."""
+    fake = _fake()
+
+    with pytest.raises(ValueError, match="Unknown dataset"):
+        fetch_table("not_a_dataset", "parameters", fetcher=fake)
+
+    assert fake.collection_calls == []
+
+
+def test_a_windows_1252_metadata_file_is_decoded():
+    """MeteoSwiss ships both encodings; the degree sign is where it shows."""
+    fake = _fake("https://data.geo.admin.ch/x/ogd-smn_meta_parameters.csv", body=_PARAMETERS_CSV.encode("windows-1252"))
+
+    df = fetch_table("smn", "parameters", fetcher=fake)
+
+    assert df["unit"].to_list() == ["°C"]
+
+
+@pytest.mark.parametrize("table", sorted(TABLES))
+def test_every_table_publishes_every_column_it_declares(table):
+    """A rename map naming a column the source does not have fails at read, not at review."""
+    spec = TABLES[table]
+    source = ";".join(spec.columns) + "\n" + ";".join("x" for _ in spec.columns) + "\n"
+    fake = _fake(f"https://data.geo.admin.ch/x/ogd-smn{spec.suffix}.csv", body=source)
+
+    df = fetch_table("smn", table, fetcher=fake)
+
+    assert df.columns == list(spec.columns.values())
+    assert df.height == 1
+    assert isinstance(df, pl.DataFrame)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,7 +6,9 @@ call the grib2 handler?" — one assertion per caller per kind, which is the
 duplication the registry removes.
 """
 
+import re
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -305,13 +307,32 @@ def test_convert_passes_the_directories_through(tmp_path):
     assert (tmp_path / "parquet" / "smn" / "smn_d_recent.parquet").exists()
 
 
-def test_write_cube_refuses_a_kind_with_no_cube_builder():
-    """NetCDF combines a multi-file match on read, so ``stack`` has nothing to assemble."""
-    with pytest.raises(ValueError, match="already combines on read"):
-        registry.write_cube(
+def test_a_stack_of_a_kind_with_no_cube_builder_falls_through_to_one_write():
+    """NetCDF combines a multi-file match on read, so ``stack`` is a no-op rather than an error.
+
+    ``api.to_zarr`` used to carry this as a branch of its own; it is the row's
+    ``cube`` that says which method writes the store.
+    """
+    with patch("foehn.registry._write_cube") as cube, patch("foehn.registry.open_grid") as opened:
+        registry.write_zarr(
             "surface_derived_grid",
             Path("unused.zarr"),
             match="rhiresd",
+            stack=True,
+            workspace=Workspace(Path("unused")),
+            fetcher=InMemoryFetcher(),
+        )
+
+    assert cube.call_count == 0
+    assert opened.call_count == 1
+
+
+def test_write_zarr_refuses_a_tabular_dataset():
+    """The row is what says whether a dataset has a Zarr path at all."""
+    with pytest.raises(ValueError, match=re.escape("Use foehn.load")):
+        registry.write_zarr(
+            "smn",
+            Path("unused.zarr"),
             workspace=Workspace(Path("unused")),
             fetcher=InMemoryFetcher(),
         )

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -8,21 +8,11 @@ bookkeeping, and destination collisions.
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import patch
-
 import pytest
 
 from foehn.assets import Asset
 from foehn.fetch import FetchError
-from foehn.transfer import (
-    DownloadResult,
-    already_current,
-    atomic_write_bytes,
-    csv_to_disk,
-    fetch_all,
-    stream_to_disk,
-)
+from foehn.transfer import DownloadResult, already_current, csv_to_disk, fetch_all, stream_to_disk
 from tests.fakes import InMemoryFetcher
 
 
@@ -169,19 +159,6 @@ def test_results_add(tmp_path):
 def test_empty_input_is_a_noop(tmp_path):
     result = fetch_all([], tmp_path, fetcher=InMemoryFetcher(), write=stream_to_disk)
     assert result == DownloadResult()
-
-
-# --- Atomic writes ---
-
-
-def test_a_failed_write_leaves_no_temp_file_behind(tmp_path):
-    """The sibling .tmp is the whole point: a crash must not leave one to be mistaken for data."""
-    target = tmp_path / "asset.csv"
-    with patch.object(Path, "replace", side_effect=OSError("disk full")), pytest.raises(OSError):
-        atomic_write_bytes(target, b"payload")
-
-    assert not target.exists()
-    assert list(tmp_path.iterdir()) == []
 
 
 # --- already_current ---

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -90,8 +90,9 @@ def test_open_dataset_honours_the_environment_variable(tmp_path, monkeypatch):
 
 def test_to_zarr_store_lands_in_the_workspace(tmp_path, monkeypatch):
     monkeypatch.setenv(DATA_DIR_ENV, str(tmp_path))
-    with patch("foehn.api.open_dataset") as mock_open, patch("foehn.api.write_zarr"):
-        mock_open.return_value = object()
-        with patch("foehn.api.sanitize_noncf_time_units", side_effect=lambda ds: ds):
-            store = foehn.to_zarr("surface_derived_grid", match="rhiresd")
+    with patch("foehn.registry.write_zarr") as mock:
+        store = foehn.to_zarr("surface_derived_grid", match="rhiresd")
+
     assert store == Workspace(tmp_path).zarr("surface_derived_grid__rhiresd")
+    assert mock.call_args.args[1] == store
+    assert mock.call_args.kwargs["workspace"] == Workspace(tmp_path)


### PR DESCRIPTION
The three items left from the architecture review. 639 tests, 99.49% branch coverage.

## State the staging rule once (`b080217`)

"Write to a sibling temp, `replace` onto the target, remove it on failure" was written out four times — the fetcher's stream (`.part`), transfer's byte writer (`.tmp`), the Parquet converter (`.tmp`) and run state — with three docstrings reasoning their way to the same rule.

The visible symptom was in the import graph: `state`, which is the run cursor and the ETag store, imported `transfer` — the download engine — for one filesystem primitive. The same shape as `transfer` importing `convert`, which already has a layering test.

`atomicwrite` is a leaf exposing `staged()`, `write_bytes()` and `write_text()`. `test_layering` now guards the rule itself, not just the imports: a module that hand-rolls `.replace(path)` fails the assertion.

## Let the public surface delegate (`e752230`)

`api` held one pipeline stage outright — the metadata tables were fetched, decoded and renamed inline — which made it the one entry point taking no fetcher and reachable only through the process-wide default. `to_zarr` separately picked cube-vs-single itself, which is the row's to say.

- `metadata` owns the tables and their implementation. `api.METADATA_TABLES` still re-exports for the CLI's argparse `choices`.
- `registry.write_zarr` owns the cube-vs-single choice and the `stack`/`rechunk` conflict. `write_cube` becomes `_write_cube` with one caller, and its "already combines on read" guard is gone — dead once the row makes the choice.
- `grids.require_dask` joins the other three optional-import guards.

`api`: 80 statements → 51, nine imports → seven, and 100% covered. `mcp_server`, a peer front end, imports two.

**One deliberate departure from the review.** I proposed routing the metadata tables through the registry like the four kind-shaped stages. On implementing it that was wrong: nothing about them varies by dataset kind, so a row and an adapter per kind would be a seam with nothing on either side of it — one adapter is a hypothetical seam. `metadata` sits below `api` as a sibling of `readers` and `grids`, reached directly. The wins the review actually wanted — implementation out of the public module, fetcher injected — both hold.

## Tests

- `test_atomicwrite.py` (6) — including that a failed write leaves the *previous* version intact, and that a KeyboardInterrupt mid-write cleans up like disk-full does.
- `test_metadata.py` (9) — all with an injected fetcher, which is what the move bought. Parametrised over every table so a rename map naming a column the source lacks fails at read.
- Three new layering assertions: `api` imports no stage module, `metadata` has one consumer, `state` no longer touches `transfer`.
- `test_write_cube_refuses_a_kind_with_no_cube_builder` became `test_a_stack_of_a_kind_with_no_cube_builder_falls_through_to_one_write` — it asserted an error that is now correctly a no-op.

## Notes

- Breaking: `transfer.atomic_write_bytes` / `atomic_write_text` → `atomicwrite.write_bytes` / `write_text`; `registry.write_cube` → `registry.write_zarr(..., stack=True)`.
- `CONTEXT.md` gains **Staging** and **Metadata table** as terms, plus both resolutions.
- Committing locally still needs `SKIP=actionlint,zizmor` (TLS in my environment); CI runs them normally.