### PR TITLE
Read the indoor archive the way every other kind is read

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@
 # CI cannot disagree about what "clean" means — they were previously kept in step
 # by hand, and a drifting ruff turns green PRs red with no code change.
 # Dependabot bumps these revs weekly (see .github/dependabot.yml).
+#
+# ty is the exception, and runs the other way round: its pin lives in the
+# pyproject dev extra, which is what CI installs from, so the hook below invokes
+# that one rather than carrying a second rev here to drift from it.
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.4
@@ -35,6 +39,20 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+
+  # The typecheck CI runs, at the same pin — foehn ships py.typed, so these
+  # annotations are a published interface. Nothing ran it before a push, and a
+  # dict whose values ty widened to a union reached a branch 69 diagnostics deep.
+  # Checks all of src/ rather than the staged files, exactly as CI does: an
+  # annotation changed in one module is what breaks the call in another.
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty check src
+        entry: uv run --extra dev ty check src/
+        language: system
+        pass_filenames: false
+        files: ^(src/foehn/.*\.py|pyproject\.toml)$
 
   # Workflow static analysis, same version CI runs.
   - repo: https://github.com/zizmorcore/zizmor-pre-commit

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -285,6 +285,14 @@ _Avoid_: query, params, options
   state** reached into **Transfer**, the download engine, for a filesystem
   primitive that was never the download path's to own. Resolved: `atomicwrite` is
   a leaf and `test_layering` fails a module that hand-rolls the move itself.
+- The **Archive CSV** kind's member files were read in two places — `readers`
+  for the load path, `convert` for the Parquet stage — each spelling out
+  upstream's separator and schema window and then calling the two `meteocsv`
+  helpers in the right order. Every other kind already had its eager reader and
+  its lazy scanner in **MeteoSwiss CSV**, each owning its own read options.
+  Resolved: `indoor_station` answers whether a member is data and whose, and
+  `parse_indoor_csv`/`scan_indoor_csv` read one. The load path now spells out no
+  CSV convention at all.
 - The Zarr store's name — `<dataset>` unfiltered, `<dataset>__<match>` otherwise —
   was derived in `api` and handed to `Workspace.zarr()` as a finished string, so
   that method documented the encoding as its caller's job. The one path foehn

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -285,6 +285,32 @@ _Avoid_: query, params, options
   state** reached into **Transfer**, the download engine, for a filesystem
   primitive that was never the download path's to own. Resolved: `atomicwrite` is
   a leaf and `test_layering` fails a module that hand-rolls the move itself.
+- The default **Time slice** was the token `"recent"`, written at four code sites
+  — the `Filters` field, its builder, `registry.download` and the CLI — and again
+  as prose in four docstrings. Resolved: `collections.DEFAULT_TIME_SLICE` is the
+  fact and every site reads it.
+- `load()`'s docstring named the **Granularity** and **Time slice** tokens as
+  prose, and so did `load_data`'s and `describe_data`'s — the latter two directly
+  under the comment in `mcp_server` saying a tool docstring is rendered from the
+  tables, never retyped beside them. The rule had been stated for one front end
+  and half-applied there. Resolved: the renderer is `docstrings.renders`, a leaf
+  under both front ends; `collections.options` renders a label table as prose;
+  and `test_docstrings` asserts every offered token reaches every surface that
+  offers it, so the rendering is load-bearing rather than a convention.
+- The layering guards that could not be asked of the import graph were substring
+  matches on the source — `".replace(path)"`, `"separator="`, `".chunk("`. Brittle
+  both ways: `"dask"` matched a comment, and `".replace(path)"` would have missed
+  `tmp.replace(target)`. Resolved: they read the tree — which names a module
+  calls, which constants it passes as a keyword, whether it calls
+  `<path>.replace(x)` with the one argument that tells `Path.replace` from
+  `str.replace`.
+- The **Standard CSV** kind's scan options were stated in the convert stage
+  rather than in **MeteoSwiss CSV**, because the dtype-drift retry is wrapped
+  around them. The last kind whose conventions sat above the module that owns
+  them. Resolved: `meteocsv.scan_standard_csv` is the lazy half of
+  `parse_csv_bytes`; the retry stays in the convert stage and passes the widened
+  types back in. What convert still spells out is the **Direct ZIP** kind's
+  tab-separated TXT, whose only reader it is.
 - The **Archive CSV** kind's member files were read in two places — `readers`
   for the load path, `convert` for the Parquet stage — each spelling out
   upstream's separator and schema window and then calling the two `meteocsv`

--- a/src/foehn/api.py
+++ b/src/foehn/api.py
@@ -8,7 +8,15 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from foehn import registry
-from foehn.collections import COLLECTION_META, COLLECTIONS
+from foehn.collections import (
+    COLLECTION_META,
+    COLLECTIONS,
+    DEFAULT_TIME_SLICE,
+    GRANULARITY_LABELS,
+    TIME_SLICE_LABELS,
+    options,
+)
+from foehn.docstrings import renders
 from foehn.fetch import DEFAULT_WORKERS, default_fetcher
 from foehn.metadata import TABLES as metadata_tables
 from foehn.metadata import fetch_table
@@ -18,6 +26,17 @@ from foehn.workspace import Workspace
 
 if TYPE_CHECKING:
     import xarray as xr
+
+# A vocabulary or a default named in a docstring is rendered from the table that
+# defines it, never retyped beside it — the argument ``mcp_server`` already makes
+# for its tool descriptions, and ``help(foehn.load)`` is the same kind of surface.
+_VOCABULARY = {
+    "granularities": options(GRANULARITY_LABELS),
+    "time_slices": options(TIME_SLICE_LABELS),
+    "default_time_slice": DEFAULT_TIME_SLICE,
+    "default_workers": str(DEFAULT_WORKERS),
+}
+
 
 __all__ = [
     "METADATA_TABLES",
@@ -43,6 +62,7 @@ def list_datasets() -> list[dict]:
     return [{"dataset": key, "collection_id": cid, **COLLECTION_META[key]} for key, cid in COLLECTIONS.items()]
 
 
+@renders(**_VOCABULARY)
 def download(
     dataset: str,
     *,
@@ -57,14 +77,15 @@ def download(
     Args:
         dataset: Dataset name (e.g. "smn"). Use list_datasets() to see options.
         data_dir: Root data directory. Defaults to ./data/meteoswiss.
-        time_slice: Time slices to download. Defaults to ["recent"]. Ignored for
-            binary/grid datasets (GRIB2/NetCDF), which fetch the latest assets.
+        time_slice: Time slices to download. Options: $time_slices.
+            Defaults to ["$default_time_slice"]. Ignored for binary/grid datasets
+            (GRIB2/NetCDF), which fetch the latest assets.
         since: ISO timestamp for incremental updates — only assets updated after
             it are fetched. This function does not track state itself: pass the
             previous run's timestamp, or use the ``foehn download`` CLI, which
             persists one in ``_last_run.json`` and only advances it when the run
             fully succeeds.
-        workers: Concurrent HTTP downloads (default 8).
+        workers: Concurrent HTTP downloads (default $default_workers).
         force: Re-download even when local files look up to date. Currently
             only affects ZIP-shipped datasets (e.g. climate_scenarios_indoor),
             which otherwise skip when already extracted; other formats refresh
@@ -175,6 +196,7 @@ def inventory(dataset: str) -> pl.DataFrame:
     return metadata(dataset, "inventory")
 
 
+@renders(**_VOCABULARY)
 def load(
     dataset: str,
     *,
@@ -201,11 +223,10 @@ def load(
         station: Station abbreviation(s) to include (e.g. "BER" or ["BER", "ZUR"]).
             Filters at the STAC item level so unmatched stations are never downloaded.
             Case-insensitive. If None, all stations are included.
-        frequency: Time frequency filter(s). Options: "t" (10-min), "h" (hourly),
-            "d" (daily), "m" (monthly), "y" (yearly). Can be a single string or list.
-            If None, all frequencies are included.
-        time_slice: Time slice(s) to include. Defaults to ["recent"].
-            Options: "historical", "recent", "now". Can be a single string or list.
+        frequency: Granularity filter(s). Options: $granularities.
+            Can be a single string or list. If None, all are included.
+        time_slice: Time slice(s) to include. Options: $time_slices.
+            Defaults to ["$default_time_slice"]. Can be a single string or list.
         year: Filter to specific year(s) (e.g. 2025 or [2020, 2021, 2022]).
         month: Filter to specific month(s) (1-12, e.g. 7 or [6, 7, 8] for summer).
         date_from: Start date (inclusive), ISO format "YYYY-MM-DD".
@@ -220,7 +241,7 @@ def load(
             network bytes, since CSVs are per-station and not pre-bucketed by
             row count. To reduce wire volume, narrow with ``time_slice="now"``,
             ``year``, or ``date_from/date_to``.
-        workers: Concurrent CSV downloads (default 8). The CSV fetches are
+        workers: Concurrent CSV downloads (default $default_workers). The CSV fetches are
             parallelised via a ThreadPoolExecutor; metadata fetch stays serial.
 
     Returns:

--- a/src/foehn/cli.py
+++ b/src/foehn/cli.py
@@ -12,7 +12,7 @@ import polars as pl
 
 from foehn import registry
 from foehn.api import METADATA_TABLES, list_datasets, metadata
-from foehn.collections import CATEGORIES, CATEGORY_LABELS, COLLECTIONS
+from foehn.collections import CATEGORIES, CATEGORY_LABELS, COLLECTIONS, DEFAULT_TIME_SLICE
 from foehn.fetch import DEFAULT_WORKERS, default_fetcher
 from foehn.state import load_last_run, save_last_run
 from foehn.workspace import Workspace
@@ -87,7 +87,7 @@ def cmd_download(args: argparse.Namespace) -> None:
 
     full_refresh = args.full_refresh or os.environ.get("FOEHN_FULL_REFRESH", "").lower() in ("1", "true", "yes")
 
-    time_slices = ["recent"]
+    time_slices = [DEFAULT_TIME_SLICE]
     if args.all or args.now:
         time_slices.append("now")
     if args.all or args.historical:

--- a/src/foehn/collections.py
+++ b/src/foehn/collections.py
@@ -503,12 +503,21 @@ CLIMATE_NORMALS_ZIP_URL = "https://data.geo.admin.ch/ch.meteoschweiz.klima/normw
 # added here has to reach the LLM-facing documentation, and prose cannot be
 # checked against a set.
 TIME_SLICE_LABELS: dict[str, str] = {
-    "now": "last ~24 hours, updated every 10 minutes (t, h only)",
-    "recent": "this calendar year through yesterday, updated daily (the default)",
+    "now": "last ~24 hours, updated every 10 minutes — t and h only",
+    "recent": "this calendar year through yesterday, updated daily",
     "historical": "start of measurements through Dec 31 of last year",
 }
 
 TIME_SLICES = frozenset(TIME_SLICE_LABELS)
+
+DEFAULT_TIME_SLICE = "recent"
+"""What a caller who names no time slice gets.
+
+The token was written at four code sites — the :class:`~foehn.readers.Filters`
+field, its builder, ``registry.download`` and the CLI — and again as prose in
+four docstrings. One of them is the whole vocabulary's default; the rest were
+copies of it.
+"""
 
 # The granularity segment's vocabulary — the ``_t``/``_h``/``_d``/``_m``/``_y``
 # documented at the top of this module. Which of them a given dataset actually
@@ -516,7 +525,7 @@ TIME_SLICES = frozenset(TIME_SLICE_LABELS)
 # the single source for it (the MCP layer used to carry its own copy of the
 # tokens, and then its own prose gloss of them).
 GRANULARITY_LABELS: dict[str, str] = {
-    "t": "10-minute (near real-time measurements)",
+    "t": "10-minute, near real-time",
     "h": "hourly",
     "d": "daily",
     "m": "monthly",
@@ -539,6 +548,16 @@ CATEGORY_LABELS: dict[str, str] = {
 }
 
 CATEGORIES = frozenset(CATEGORY_LABELS)
+
+
+def options(labels: dict[str, str]) -> str:
+    """One of the label tables as inline prose: ``"t" (10-minute, near real-time), …``.
+
+    What a docstring's Args block wants, where the MCP guide wants bullets. Both
+    are rendered from the table; neither is retyped beside it, which is the only
+    way prose and a set can be checked against each other.
+    """
+    return ", ".join(f'"{token}" ({label})' for token, label in labels.items())
 
 
 # MeteoSwiss chunks the high-frequency historical series by decade, so the slice

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -18,13 +18,13 @@ import polars as pl
 
 from foehn.atomicwrite import staged
 from foehn.meteocsv import (
-    add_indoor_columns,
     column_from_dtype_error,
     derive_timestamp,
     group_csv_files,
+    indoor_station,
     load_metadata_types,
-    parse_indoor_filename,
     scan_climate_scenarios_csv,
+    scan_indoor_csv,
 )
 from foehn.workspace import Workspace
 
@@ -212,22 +212,12 @@ def convert_indoor_to_parquet(dataset: str, workspace: Workspace) -> int:
         frames: list[pl.LazyFrame] = []
         skipped = 0
         for f in group.sources:
-            parsed = parse_indoor_filename(f.stem)
-            if parsed is None:
+            if indoor_station(f.name) is None:
                 # The archive ships a metadata CSV alongside the data; not a failure.
                 skipped += 1
                 logger.info("  Skipping non-data file: %s", f.name)
                 continue
-            station, period, scenario, variant = parsed
-            frames.append(
-                add_indoor_columns(
-                    pl.scan_csv(f, separator=",", infer_schema_length=10_000, truncate_ragged_lines=True),
-                    station,
-                    period,
-                    scenario,
-                    variant,
-                )
-            )
+            frames.append(scan_indoor_csv(f))
         if not frames:
             return 0
         _write_parquet_atomic(pl.concat(frames, how="diagonal_relaxed"), group.out_path)

--- a/src/foehn/convert.py
+++ b/src/foehn/convert.py
@@ -25,6 +25,7 @@ from foehn.meteocsv import (
     load_metadata_types,
     scan_climate_scenarios_csv,
     scan_indoor_csv,
+    scan_standard_csv,
 )
 from foehn.workspace import Workspace
 
@@ -132,16 +133,7 @@ def _convert_standard_group(collection_key: str, metadata_types: dict[str, type[
         recovered: list[str] = []
         while True:
             try:
-                lazy_frames = [
-                    pl.scan_csv(
-                        f,
-                        separator=";",
-                        try_parse_dates=True,
-                        schema_overrides=overrides or None,
-                        infer_schema_length=10_000,
-                    )
-                    for f in group.sources
-                ]
+                lazy_frames = [scan_standard_csv(f, schema_overrides=overrides) for f in group.sources]
                 combined = pl.concat(lazy_frames, how="diagonal_relaxed")
                 combined = derive_timestamp(combined, collection_key)
                 _write_parquet_atomic(combined, group.out_path)

--- a/src/foehn/docstrings.py
+++ b/src/foehn/docstrings.py
@@ -1,0 +1,42 @@
+"""Filling a public docstring's placeholders from the tables it would otherwise retype.
+
+A docstring is an interface: ``help(foehn.load)`` and an MCP tool's description
+are what a caller — human or model — actually reads. So a vocabulary stated in
+code and restated there can only agree with it or drift from it, and prose
+cannot be checked against a set.
+
+The MCP layer worked this out first and rendered its guide from the tables. This
+is the same decorator, moved below both front ends so ``api`` can use it too:
+``load()``'s docstring named the granularity and time-slice tokens as prose, and
+so did two of the tool docstrings sitting under the comment saying they would
+not.
+
+Sits under everything and imports nothing of foehn's — it knows about text, not
+about datasets.
+"""
+
+from __future__ import annotations
+
+from string import Template
+from typing import TypeVar
+
+F = TypeVar("F")
+
+
+def renders(**fragments: str):
+    """Fill a docstring's ``$name`` placeholders before anything reads it.
+
+    Spelled ``$name`` rather than ``{name}`` so a docstring stays free to contain
+    a brace. Where a registration decorator is involved this must sit *below* it,
+    so the finished text is what registers.
+    """
+
+    def apply(fn: F) -> F:
+        if fn.__doc__:  # python -OO strips docstrings
+            fn.__doc__ = Template(fn.__doc__).safe_substitute(**fragments)
+        return fn
+
+    return apply
+
+
+__all__ = ["renders"]

--- a/src/foehn/mcp_server.py
+++ b/src/foehn/mcp_server.py
@@ -10,7 +10,6 @@ GRIB2, or radar) into the local bronze cache (annotated ``read_only_hint=False``
 from __future__ import annotations
 
 import logging
-from string import Template
 from typing import Literal
 
 from mcp.server.mcpserver import MCPServer
@@ -24,9 +23,12 @@ from foehn.collections import (
     CATEGORY_LABELS,
     COLLECTION_META,
     COLLECTIONS,
+    DEFAULT_TIME_SLICE,
     GRANULARITY_LABELS,
     TIME_SLICE_LABELS,
+    options,
 )
+from foehn.docstrings import renders
 
 logger = logging.getLogger(__name__)
 
@@ -68,24 +70,18 @@ _INSPECTABLE_GRIDS = sorted(registry.grid_datasets())
 # treatment as the guide: rendered from the tables, never retyped beside them.
 # Both had already drifted. The guide told callers ``sort`` defaults to "asc";
 # ``load_data`` named twelve loadable datasets when the registry had thirteen.
-_LOADABLE_LIST = ", ".join(_LOADABLE_DATASETS)
-_CATEGORY_OPTIONS = ", ".join(f'"{code}" ({label.lower()})' for code, label in CATEGORY_LABELS.items())
 _CATEGORY_CODES = ", ".join(sorted(CATEGORIES))
 
-
-def _renders(**fragments: str):
-    """Fill a tool docstring's placeholders before the server reads it.
-
-    Spelled ``$name`` rather than ``{name}`` so a docstring stays free to contain
-    a brace. Sits *below* ``@mcp.tool`` so the finished text is what registers.
-    """
-
-    def apply(fn):
-        if fn.__doc__:  # python -OO strips docstrings
-            fn.__doc__ = Template(fn.__doc__).safe_substitute(**fragments)
-        return fn
-
-    return apply
+# What every tool docstring below is filled from. ``load_data`` and
+# ``describe_data`` used to name the granularity and time-slice tokens as prose,
+# directly under the comment above saying they would not.
+_VOCABULARY = {
+    "loadable": ", ".join(_LOADABLE_DATASETS),
+    "categories": options(CATEGORY_LABELS),
+    "granularities": options(GRANULARITY_LABELS),
+    "time_slices": options(TIME_SLICE_LABELS),
+    "default_time_slice": DEFAULT_TIME_SLICE,
+}
 
 
 mcp = MCPServer(
@@ -120,7 +116,7 @@ mcp = MCPServer(
 class Dataset(BaseModel):
     dataset: str = Field(description="Short name used in API calls (e.g. 'smn')")
     collection_id: str = Field(description="STAC collection ID")
-    category: str = Field(description=f"MeteoSwiss category: {_CATEGORY_OPTIONS}")
+    category: str = Field(description=f"MeteoSwiss category: {_VOCABULARY['categories']}")
     subcategory: str = Field(description="Subcategory code (e.g. 'A1')")
     description: str = Field(description="Human-readable description")
     format: str = Field(description="Data format (CSV, GRIB2, NetCDF, etc.)")
@@ -198,7 +194,7 @@ class GridSummary(BaseModel):
 
 
 @mcp.tool(title="List datasets", annotations=_READ_ONLY)
-@_renders(categories=_CATEGORY_OPTIONS)
+@renders(**_VOCABULARY)
 def list_datasets(category: str | None = None) -> list[Dataset]:
     """List all available MeteoSwiss datasets.
 
@@ -218,7 +214,7 @@ def list_datasets(category: str | None = None) -> list[Dataset]:
 
 
 @mcp.tool(title="Load data", annotations=_READ_ONLY)
-@_renders(loadable=_LOADABLE_LIST)
+@renders(**_VOCABULARY)
 def load_data(
     dataset: str,
     station: list[str] | None = None,
@@ -249,11 +245,10 @@ def load_data(
         station: Station abbreviation(s) (e.g. ["BER"] for Bern, or ["BER", "ZUR"]).
             Case-insensitive. Use get_stations() to find abbreviations.
             If omitted, returns all stations (may be large).
-        frequency: Time frequency. Options: "t" (10-min), "h" (hourly), "d" (daily),
-            "m" (monthly), "y" (yearly). Not all datasets support all frequencies —
-            check list_datasets() for the "frequencies" field.
-        time_slice: Time period. Options: "historical" (start of measurements to end
-            of last year), "recent" (this calendar year, default), "now" (last 24h).
+        frequency: Granularity. Options: $granularities. Not all datasets support
+            all of them — check list_datasets() for the "frequencies" field.
+        time_slice: Time period. Options: $time_slices.
+            Defaults to "$default_time_slice".
         year: Filter to specific year(s) (e.g. [2025] or [2020, 2021, 2022]).
             Applied after loading, so use with time_slice="historical" to get
             past years without hitting the row limit.
@@ -298,6 +293,7 @@ def load_data(
 
 
 @mcp.tool(title="Describe data", annotations=_READ_ONLY)
+@renders(**_VOCABULARY)
 def describe_data(
     dataset: str,
     station: list[str] | None = None,
@@ -328,8 +324,8 @@ def describe_data(
     Args:
         dataset: Dataset name (e.g. "smn"). Call list_datasets() to see options.
         station: Station abbreviation(s) to filter by.
-        frequency: Time frequency filter ("t", "h", "d", "m", "y").
-        time_slice: Time period ("historical", "recent", "now").
+        frequency: Granularity filter. Options: $granularities.
+        time_slice: Time period. Options: $time_slices.
         year: Filter to specific year(s) (e.g. [2025]).
         month: Filter to specific month(s) (1-12).
         date_from: Start date (inclusive), ISO format "YYYY-MM-DD".

--- a/src/foehn/meteocsv.py
+++ b/src/foehn/meteocsv.py
@@ -245,6 +245,28 @@ def parse_csv_bytes(
         raise last_err from None
 
 
+def scan_standard_csv(path: Path, *, schema_overrides: dict[str, type[pl.DataType]] | None = None):
+    """Lazily scan one standard MeteoSwiss CSV, without reading it.
+
+    The lazy half of :func:`parse_csv_bytes`, which is the eager one. The convert
+    stage used to spell these options out itself — the last kind whose conventions
+    were stated above this module — because the dtype-drift retry is wrapped
+    around the scan. That retry is the convert stage's: it re-runs the sink, and
+    passes the widened types back in through *schema_overrides*.
+
+    A wider schema window than the eager path's, on purpose: a scan pays for the
+    inferred rows once per file rather than holding the file, and the converter's
+    groups are whole historical series.
+    """
+    return pl.scan_csv(
+        path,
+        separator=";",
+        try_parse_dates=True,
+        schema_overrides=schema_overrides or None,
+        infer_schema_length=10_000,
+    )
+
+
 def add_forecast_local_timestamp(frame):
     """Add a parsed reference_timestamp from forecast_local's compact Date column.
 

--- a/src/foehn/meteocsv.py
+++ b/src/foehn/meteocsv.py
@@ -323,23 +323,60 @@ def group_csv_files(csv_dir: Path, collection_key: str) -> dict[tuple[str, ...],
 
 _INDOOR_TIME_COLS = ["time.yy", "time.mm", "time.dd", "time.hh"]
 
+# How MeteoSwiss writes the indoor archive's member CSVs: comma-separated, with
+# the timestamp split across four integer columns. Stated once, for both the
+# eager read and the lazy scan — the load path and the convert stage each used
+# to spell them out.
+_INDOOR_CSV_OPTIONS = {"separator": ",", "infer_schema_length": 10_000, "truncate_ragged_lines": True}
 
-def parse_indoor_filename(stem: str) -> tuple[str, str, str, str] | None:
-    """Parse an indoor scenario filename into (station, period, scenario, variant).
+
+def indoor_station(filename: str) -> str | None:
+    """Whose data an indoor archive member is, or None if it is not data at all.
 
     Data files are ``{station}_{period}_{scenario}_{variant}`` with a 4-digit
-    year as the period. Returns None for anything else (e.g. the archive's
-    metadata CSV), so callers can skip non-data files.
+    year as the period; the archive ships a metadata CSV alongside them. Both
+    callers ask this before reading — the load path to skip a station it was not
+    asked for, the convert stage to count what it skipped — so it is one
+    question, asked of the name, and not a by-product of parsing the file.
     """
-    parts = stem.split("_")
+    parsed = _parse_indoor_filename(filename)
+    return None if parsed is None else parsed[0]
+
+
+def _parse_indoor_filename(filename: str) -> tuple[str, str, str, str] | None:
+    """Split a member's stem into (station, period, scenario, variant), or None."""
+    parts = Path(filename).name.removesuffix(".csv").split("_")
     if len(parts) < 4 or not parts[1].isdigit():
         return None
     return parts[0], parts[1], parts[2], "_".join(parts[3:])
 
 
-def add_indoor_columns(frame, station: str, period: str, scenario: str, variant: str):
+def parse_indoor_csv(content: bytes, filename: str) -> pl.DataFrame:
+    """Read one indoor archive member from memory, tagged from its filename.
+
+    The in-memory path, used when the ZIP is streamed rather than extracted; the
+    converter uses :func:`scan_indoor_csv`. Both are given a member the caller
+    has already accepted via :func:`indoor_station`.
+    """
+    return _add_indoor_columns(pl.read_csv(content, **_INDOOR_CSV_OPTIONS), _indoor_identity(filename))
+
+
+def scan_indoor_csv(path: Path) -> pl.LazyFrame:
+    """Lazily scan one extracted indoor archive member, tagged from its filename."""
+    return _add_indoor_columns(pl.scan_csv(path, **_INDOOR_CSV_OPTIONS), _indoor_identity(path.name))
+
+
+def _indoor_identity(filename: str) -> tuple[str, str, str, str]:
+    parsed = _parse_indoor_filename(filename)
+    if parsed is None:
+        raise ValueError(f"{filename!r} is not an indoor data CSV — check indoor_station() before reading it.")
+    return parsed
+
+
+def _add_indoor_columns(frame, identity: tuple[str, str, str, str]):
     """Add reference_timestamp + filename-derived columns and drop the raw time
     columns. Works on both a LazyFrame (scan_csv) and a DataFrame (read_csv)."""
+    station, period, scenario, variant = identity
     return frame.with_columns(
         pl.datetime(
             pl.col("time.yy"),
@@ -357,7 +394,7 @@ def add_indoor_columns(frame, station: str, period: str, scenario: str, variant:
 _CS_HEADER_PREFIX = "DATE;"
 
 
-def parse_climate_scenarios_filename(filename: str) -> tuple[str, str, str]:
+def _parse_climate_scenarios_filename(filename: str) -> tuple[str, str, str]:
     """Parse a climate-scenario filename into (station, variable, gwl).
 
     Files are named ``ogd-climate-scenarios-ch2025_{station}_{variable}_{gwl}``.
@@ -373,7 +410,7 @@ def parse_climate_scenarios_filename(filename: str) -> tuple[str, str, str]:
     return parts[-3], parts[-2], parts[-1]
 
 
-def add_climate_scenarios_columns(frame, station: str, variable: str, gwl: str):
+def _add_climate_scenarios_columns(frame, station: str, variable: str, gwl: str):
     """Add filename-derived columns and move the key columns to the front.
 
     Works on both a LazyFrame (scan_csv) and a DataFrame (read_csv)."""
@@ -406,7 +443,7 @@ def parse_climate_scenarios_csv(content: bytes | str, filename: str) -> pl.DataF
     if header_idx is None:
         raise ValueError(f"No 'DATE;' data header found in {filename!r}")
 
-    station, variable, gwl = parse_climate_scenarios_filename(filename)
+    station, variable, gwl = _parse_climate_scenarios_filename(filename)
 
     table = "\n".join(lines[header_idx:])
     df = pl.read_csv(
@@ -415,7 +452,7 @@ def parse_climate_scenarios_csv(content: bytes | str, filename: str) -> pl.DataF
         infer_schema_length=20_000,
         truncate_ragged_lines=True,
     )
-    return add_climate_scenarios_columns(df, station, variable, gwl)
+    return _add_climate_scenarios_columns(df, station, variable, gwl)
 
 
 def _climate_scenarios_preamble_lines(path: Path) -> int:
@@ -438,7 +475,7 @@ def scan_climate_scenarios_csv(path: Path) -> pl.LazyFrame:
     newlines, ignoring CSV quoting, so a stray quote in a metadata value can't
     shift the header offset.
     """
-    station, variable, gwl = parse_climate_scenarios_filename(path.name)
+    station, variable, gwl = _parse_climate_scenarios_filename(path.name)
     lf = pl.scan_csv(
         path,
         separator=";",
@@ -446,4 +483,4 @@ def scan_climate_scenarios_csv(path: Path) -> pl.LazyFrame:
         infer_schema_length=20_000,
         truncate_ragged_lines=True,
     )
-    return add_climate_scenarios_columns(lf, station, variable, gwl)
+    return _add_climate_scenarios_columns(lf, station, variable, gwl)

--- a/src/foehn/meteocsv.py
+++ b/src/foehn/meteocsv.py
@@ -23,6 +23,7 @@ import io
 import logging
 import re
 from pathlib import Path
+from typing import TypedDict
 
 import polars as pl
 
@@ -345,11 +346,28 @@ def group_csv_files(csv_dir: Path, collection_key: str) -> dict[tuple[str, ...],
 
 _INDOOR_TIME_COLS = ["time.yy", "time.mm", "time.dd", "time.hh"]
 
-# How MeteoSwiss writes the indoor archive's member CSVs: comma-separated, with
-# the timestamp split across four integer columns. Stated once, for both the
-# eager read and the lazy scan — the load path and the convert stage each used
-# to spell them out.
-_INDOOR_CSV_OPTIONS = {"separator": ",", "infer_schema_length": 10_000, "truncate_ragged_lines": True}
+
+class _IndoorCsvOptions(TypedDict):
+    """How MeteoSwiss writes the indoor archive's member CSVs.
+
+    A TypedDict rather than a plain dict so the two ``**`` unpackings below stay
+    checked: a plain one widens every value to the union of all of them, and
+    ``separator=`` then looks like it might be handed an ``int``.
+    """
+
+    separator: str
+    infer_schema_length: int
+    truncate_ragged_lines: bool
+
+
+# Comma-separated, with the timestamp split across four integer columns. Stated
+# once, for both the eager read and the lazy scan — the load path and the convert
+# stage each used to spell them out.
+_INDOOR_CSV_OPTIONS: _IndoorCsvOptions = {
+    "separator": ",",
+    "infer_schema_length": 10_000,
+    "truncate_ragged_lines": True,
+}
 
 
 def indoor_station(filename: str) -> str | None:

--- a/src/foehn/readers.py
+++ b/src/foehn/readers.py
@@ -24,7 +24,6 @@ import re
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Protocol
 
 import polars as pl
@@ -35,12 +34,12 @@ from foehn.assets import assets_of, collection_assets, hrefs, select
 from foehn.collections import COLLECTIONS, DatasetKind, kind
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
 from foehn.meteocsv import (
-    add_indoor_columns,
     decode_meteoswiss_csv,
     derive_timestamp,
+    indoor_station,
     parse_climate_scenarios_csv,
     parse_csv_bytes,
-    parse_indoor_filename,
+    parse_indoor_csv,
     parse_metadata_types,
     source_columns_for,
     utf8_meteoswiss_csv,
@@ -387,15 +386,15 @@ def read_archive(dataset: str, filters: Filters, *, fetcher: Fetcher) -> pl.Data
         for name in zf.namelist():
             if not name.endswith(".csv"):
                 continue
-            parsed = parse_indoor_filename(Path(name).stem)
-            if parsed is None:
+            # Asked of the name, before the member is read: an unwanted station's
+            # CSV is never parsed, and the archive's metadata CSV has no station.
+            station = indoor_station(name)
+            if station is None:
                 continue
-            st, period, scenario, variant = parsed
-            if filters.stations is not None and st.lower() not in filters.stations:
+            if filters.stations is not None and station.lower() not in filters.stations:
                 continue
             with zf.open(name) as fh:
-                frame = pl.read_csv(fh.read(), separator=",", infer_schema_length=10_000, truncate_ragged_lines=True)
-            frames.append(add_indoor_columns(frame, st, period, scenario, variant))
+                frames.append(parse_indoor_csv(fh.read(), name))
 
     if not frames:
         stations = sorted(filters.stations) if filters.stations else None

--- a/src/foehn/readers.py
+++ b/src/foehn/readers.py
@@ -31,7 +31,7 @@ import polars as pl
 from foehn._urls import asset_filename
 from foehn.archives import check_zip_size
 from foehn.assets import assets_of, collection_assets, hrefs, select
-from foehn.collections import COLLECTIONS, DatasetKind, kind
+from foehn.collections import COLLECTIONS, DEFAULT_TIME_SLICE, DatasetKind, kind
 from foehn.fetch import DEFAULT_WORKERS, Fetcher
 from foehn.meteocsv import (
     decode_meteoswiss_csv,
@@ -67,7 +67,7 @@ class Filters:
     granularities: frozenset[str] | None = None
     """Lowercased granularity codes, or None for no filter."""
 
-    time_slices: tuple[str, ...] = ("recent",)
+    time_slices: tuple[str, ...] = (DEFAULT_TIME_SLICE,)
     year: tuple[int, ...] | None = None
     month: tuple[int, ...] | None = None
     date_from: str | None = None
@@ -105,7 +105,7 @@ class Filters:
         return cls(
             stations=_lower_set(station),
             granularities=_lower_set(frequency),
-            time_slices=_as_tuple(time_slice) or ("recent",),
+            time_slices=_as_tuple(time_slice) or (DEFAULT_TIME_SLICE,),
             year=_as_tuple(year),
             month=_as_tuple(month),
             date_from=date_from,

--- a/src/foehn/registry.py
+++ b/src/foehn/registry.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Protocol
 from foehn.collections import (
     COLLECTION_META,
     COLLECTIONS,
+    DEFAULT_TIME_SLICE,
     GRANULARITIES,
     KIND_OF,
     TIME_SLICES,
@@ -318,7 +319,7 @@ def download(
     return spec(dataset).download(
         dataset,
         workspace,
-        time_slice=time_slice or ["recent"],
+        time_slice=time_slice or [DEFAULT_TIME_SLICE],
         since=since,
         workers=workers,
         force=force,

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,72 @@
+"""That a public docstring never restates a vocabulary the code already holds.
+
+``help(foehn.load)`` and an MCP tool's description are what a caller — human or
+model — actually reads, so they are interfaces. A token list typed into one can
+only agree with the table that defines it or drift from it, and prose cannot be
+checked against a set. Both had drifted before: the MCP guide claimed ``sort``
+defaults to "asc" when an omitted ``sort`` does not sort at all, and
+``load_data`` named twelve loadable datasets when the registry had thirteen.
+
+These tests are what makes the rendering load-bearing: add a granularity to
+``GRANULARITY_LABELS`` and every surface that offers one has to show it.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import foehn
+from foehn.collections import (
+    CATEGORY_LABELS,
+    DEFAULT_TIME_SLICE,
+    GRANULARITY_LABELS,
+    TIME_SLICE_LABELS,
+    options,
+)
+from foehn.fetch import DEFAULT_WORKERS
+
+mcp_server = pytest.importorskip("foehn.mcp_server", reason="mcp not installed")
+
+
+def _doc(fn) -> str:
+    doc = inspect.getdoc(fn)
+    assert doc, f"{fn.__name__} has no docstring to render into"
+    return doc
+
+
+# The surfaces that offer a filter, and which vocabularies each one offers.
+_OFFERS = [
+    (foehn.load, (GRANULARITY_LABELS, TIME_SLICE_LABELS)),
+    (foehn.download, (TIME_SLICE_LABELS,)),
+    (mcp_server.load_data, (GRANULARITY_LABELS, TIME_SLICE_LABELS)),
+    (mcp_server.describe_data, (GRANULARITY_LABELS, TIME_SLICE_LABELS)),
+    (mcp_server.list_datasets, (CATEGORY_LABELS,)),
+]
+
+
+@pytest.mark.parametrize(("fn", "tables"), _OFFERS, ids=lambda v: getattr(v, "__name__", ""))
+def test_every_offered_token_reaches_the_docstring(fn, tables):
+    """A token added to a table has to show up wherever that filter is offered."""
+    doc = _doc(fn)
+    for table in tables:
+        assert options(table) in doc, f"{fn.__name__} does not render {sorted(table)}"
+
+
+@pytest.mark.parametrize("fn", [pair[0] for pair in _OFFERS], ids=lambda v: v.__name__)
+def test_no_placeholder_survives_into_a_public_docstring(fn):
+    """An unfilled ``$name`` is a fragment key that was renamed or misspelled."""
+    assert "$" not in _doc(fn)
+
+
+@pytest.mark.parametrize("fn", [foehn.load, foehn.download, mcp_server.load_data], ids=lambda v: v.__name__)
+def test_the_documented_time_slice_default_is_the_real_one(fn):
+    assert DEFAULT_TIME_SLICE in _doc(fn)
+
+
+@pytest.mark.parametrize("fn", [foehn.load, foehn.download], ids=lambda v: v.__name__)
+def test_the_documented_worker_count_is_the_signature_default(fn):
+    """The one number a caller plans around, and it was typed out twice."""
+    assert inspect.signature(fn).parameters["workers"].default == DEFAULT_WORKERS
+    assert f"default {DEFAULT_WORKERS}" in _doc(fn)

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -181,3 +181,23 @@ def test_the_registry_routes_a_zarr_write_without_knowing_the_recipe():
     assert "sanitize" not in source
     assert "require_dask" not in source
     assert ".chunk(" not in source
+
+
+def test_the_load_path_reads_no_csv_itself():
+    """Every CSV the load path parses is parsed by ``meteocsv``.
+
+    The indoor archive's members were the exception: their separator and schema
+    window were spelled out in ``readers`` and again in ``convert``, above the
+    module that owns upstream's conventions, while every other kind already had
+    an eager reader and a lazy scanner down there.
+    """
+    source = (SRC / "readers.py").read_text(encoding="utf-8")
+    assert "separator=" not in source
+    assert "read_csv" not in source
+
+
+def test_the_convert_stage_states_no_indoor_csv_conventions():
+    """The other half of the same duplication. Its remaining ``separator=`` literals
+    are the standard kind's, wrapped in the dtype-drift retry, and the normals TXT.
+    """
+    assert 'separator=","' not in (SRC / "convert.py").read_text(encoding="utf-8")

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -34,6 +34,57 @@ def _imports(module: str) -> set[str]:
     return found - {module}
 
 
+def _calls(module: str) -> set[str]:
+    """Every function or method name called in *module*.
+
+    Read from the tree rather than matched in the text: ``"dask" in source`` was
+    true of a comment, and ``".chunk(" in source`` would be true of a docstring.
+    A rule worth asserting is worth asserting about the code.
+    """
+    tree = ast.parse((SRC / f"{module}.py").read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            names.add(node.func.id)
+        elif isinstance(node.func, ast.Attribute):
+            names.add(node.func.attr)
+    return names
+
+
+def _keyword_values(module: str, keyword: str) -> set[object]:
+    """Every constant passed as *keyword* at a call in *module*."""
+    tree = ast.parse((SRC / f"{module}.py").read_text(encoding="utf-8"))
+    found: set[object] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == keyword and isinstance(kw.value, ast.Constant):
+                found.add(kw.value.value)
+    return found
+
+
+def _renames_a_path(module: str) -> bool:
+    """Whether *module* calls ``<path>.replace(target)`` — the move half of staging.
+
+    One positional argument and no keywords is what tells it apart from
+    ``str.replace``, which takes at least two. The substring this replaces could
+    not, which is why it was spelled ``.replace(path)`` and would have missed
+    ``.replace(self.target)``.
+    """
+    tree = ast.parse((SRC / f"{module}.py").read_text(encoding="utf-8"))
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "replace"
+        and len(node.args) == 1
+        and not node.keywords
+        for node in ast.walk(tree)
+    )
+
+
 def _graph() -> dict[str, set[str]]:
     return {p.stem: _imports(p.stem) for p in SRC.glob("*.py") if p.stem != "__init__"}
 
@@ -91,9 +142,12 @@ def test_meteocsv_is_the_bottom_of_the_read_stack():
     assert _imports("meteocsv") <= {"collections"}
 
 
-@pytest.mark.parametrize("module", ["collections", "workspace", "_urls", "archives", "odim", "atomicwrite"])
+@pytest.mark.parametrize(
+    "module", ["collections", "workspace", "_urls", "archives", "odim", "atomicwrite", "docstrings"]
+)
 def test_the_leaf_modules_import_no_foehn(module):
-    """Dataset facts, the layout, URL validation, the ZIP guards, ODIM and staging sit under everything.
+    """Dataset facts, the layout, URL validation, the ZIP guards, ODIM, staging and
+    docstring rendering sit under everything.
 
     ``odim`` is upstream's radar file format and nothing else: one path in, one
     Dataset out. It takes ``xr`` as an argument rather than importing it, so it
@@ -129,12 +183,11 @@ def test_every_write_to_the_workspace_stages():
     Guards the rule itself rather than the imports: a fifth writer that hand-rolls
     ``.replace`` is exactly the regression this split was for.
     """
-    hand_rolled = {
-        module
-        for module in ("transfer", "convert", "fetch", "state", "downloads", "gridfiles")
-        if ".replace(path)" in (SRC / f"{module}.py").read_text(encoding="utf-8")
-    }
+    writers = ("transfer", "convert", "fetch", "state", "downloads", "gridfiles")
+    hand_rolled = {module for module in writers if _renames_a_path(module)}
     assert hand_rolled == set()
+    # And the rule has somewhere to live: the leaf that owns it does the move.
+    assert _renames_a_path("atomicwrite")
 
 
 def test_the_public_surface_only_delegates():
@@ -177,10 +230,10 @@ def test_the_registry_routes_a_zarr_write_without_knowing_the_recipe():
     Guards the rule rather than the imports: restating either step above the
     seam is the regression, however it is spelled.
     """
-    source = (SRC / "registry.py").read_text(encoding="utf-8")
-    assert "sanitize" not in source
-    assert "require_dask" not in source
-    assert ".chunk(" not in source
+    called = _calls("registry")
+    assert not {name for name in called if "sanitize" in name}
+    assert "require_dask" not in called
+    assert "chunk" not in called
 
 
 def test_the_load_path_reads_no_csv_itself():
@@ -191,13 +244,20 @@ def test_the_load_path_reads_no_csv_itself():
     module that owns upstream's conventions, while every other kind already had
     an eager reader and a lazy scanner down there.
     """
-    source = (SRC / "readers.py").read_text(encoding="utf-8")
-    assert "separator=" not in source
-    assert "read_csv" not in source
+    called = _calls("readers")
+    assert not called & {"read_csv", "scan_csv"}
+    assert _keyword_values("readers", "separator") == set()
 
 
-def test_the_convert_stage_states_no_indoor_csv_conventions():
-    """The other half of the same duplication. Its remaining ``separator=`` literals
-    are the standard kind's, wrapped in the dtype-drift retry, and the normals TXT.
+def test_the_convert_stage_states_one_upstream_convention():
+    """The normals TXT, and nothing else.
+
+    The indoor archive's separator was stated here and in ``readers``; the
+    standard kind's was stated here and, differently, in ``meteocsv`` — the last
+    kind whose conventions sat above the module that owns them, because the
+    dtype-drift retry is wrapped around its scan. The retry stayed; the scan
+    moved. What is left is the **Direct ZIP** kind's tab-separated TXT, which has
+    no reader of its own: this stage is its only consumer, so a seam for it would
+    have exactly one adapter.
     """
-    assert 'separator=","' not in (SRC / "convert.py").read_text(encoding="utf-8")
+    assert _keyword_values("convert", "separator") == {"\t"}

--- a/tests/test_meteocsv.py
+++ b/tests/test_meteocsv.py
@@ -342,3 +342,27 @@ def test_a_non_dtype_failure_on_retry_is_raised_as_itself():
 
     with patch.object(pl, "read_csv", side_effect=attempts), pytest.raises(MemoryError):
         parse_csv_bytes(data, metadata_types={"tre200d0": pl.Int64})
+
+
+# --- The indoor archive's members ---
+
+
+def test_the_archives_metadata_csv_has_no_station():
+    """The one member that is not data, and the question both pipelines ask of a name."""
+    from foehn.meteocsv import indoor_station
+
+    assert indoor_station("ABO_2035_RCP85_DRY.csv") == "ABO"
+    assert indoor_station("indoor/AIG_2060_RCP26_DRY_v2.csv") == "AIG"
+    assert indoor_station("metadata.csv") is None
+
+
+def test_reading_a_non_data_member_says_to_ask_first():
+    """Whether a member is data is ``indoor_station``'s answer, asked before the read.
+
+    The readers take a member the caller has already accepted, so reaching one
+    of them with the metadata CSV is a caller error rather than a row to skip.
+    """
+    from foehn.meteocsv import parse_indoor_csv
+
+    with pytest.raises(ValueError, match="indoor_station"):
+        parse_indoor_csv(b"a,b\n1,2\n", "metadata.csv")


### PR DESCRIPTION
Its member CSVs were read in two places — readers for the load path, convert for the Parquet stage — each spelling out upstream's separator and schema window, then calling the same two meteocsv helpers in the same order. Every other kind already had an eager reader and a lazy scanner in meteocsv, each owning its own read options; this kind had the helpers but not the pair.

indoor_station answers whether a member is data and whose, which is what both callers ask before reading — one to skip a station it was not asked for, the other to count what it skipped. parse_indoor_csv and scan_indoor_csv read one. readers now spells out no CSV convention at all, which is what test_layering asserts.